### PR TITLE
fix(library): add fallback for MP3 files with UTF-16 encoded ID3 tags

### DIFF
--- a/internal/player/metadata_test.go
+++ b/internal/player/metadata_test.go
@@ -1,0 +1,219 @@
+package player
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bogem/id3v2/v2"
+)
+
+// createMinimalMP3 creates a minimal valid MP3 file for testing.
+// Returns MP3 frame header + padding (417 bytes total for 128kbps frame).
+func createMinimalMP3(t *testing.T, path string) {
+	t.Helper()
+	// MP3 frame header (MPEG1 Layer3, 128kbps, 44100Hz, stereo) + padding
+	mp3Frame := make([]byte, 417)
+	mp3Frame[0] = 0xff
+	mp3Frame[1] = 0xfb
+	mp3Frame[2] = 0x90
+	mp3Frame[3] = 0x00
+
+	if err := os.WriteFile(path, mp3Frame, 0o600); err != nil {
+		t.Fatalf("failed to create test MP3: %v", err)
+	}
+}
+
+func TestParseTrackNumber(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantNum   int
+		wantTotal int
+	}{
+		{"", 0, 0},
+		{"5", 5, 0},
+		{"5/10", 5, 10},
+		{"1/1", 1, 1},
+		{"12/24", 12, 24},
+		{"invalid", 0, 0},
+		{"5/invalid", 5, 0},
+		{"invalid/10", 0, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			num, total := parseTrackNumber(tt.input)
+			if num != tt.wantNum {
+				t.Errorf("parseTrackNumber(%q) num = %d, want %d", tt.input, num, tt.wantNum)
+			}
+			if total != tt.wantTotal {
+				t.Errorf("parseTrackNumber(%q) total = %d, want %d", tt.input, total, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestReadMP3WithID3v2Fallback(t *testing.T) {
+	// Create a temporary MP3 file with ID3v2 tags
+	tmpDir := t.TempDir()
+	mp3Path := filepath.Join(tmpDir, "test.mp3")
+	createMinimalMP3(t, mp3Path)
+
+	// Add ID3v2 tags using the bogem/id3v2 library
+	tag, err := id3v2.Open(mp3Path, id3v2.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("failed to open MP3 for tagging: %v", err)
+	}
+
+	tag.SetTitle("Test Title")
+	tag.SetArtist("Test Artist")
+	tag.SetAlbum("Test Album")
+	tag.SetYear("2024")
+	tag.SetGenre("Rock")
+	tag.AddTextFrame("TRCK", id3v2.EncodingUTF8, "3/12")
+	tag.AddTextFrame("TPOS", id3v2.EncodingUTF8, "1/2")
+	tag.AddTextFrame("TPE2", id3v2.EncodingUTF8, "Test Album Artist")
+
+	if err := tag.Save(); err != nil {
+		t.Fatalf("failed to save ID3 tags: %v", err)
+	}
+	tag.Close()
+
+	// Test the fallback function
+	info, err := readMP3WithID3v2Fallback(mp3Path)
+	if err != nil {
+		t.Fatalf("readMP3WithID3v2Fallback failed: %v", err)
+	}
+
+	// Verify metadata
+	if info.Title != "Test Title" {
+		t.Errorf("Title = %q, want %q", info.Title, "Test Title")
+	}
+	if info.Artist != "Test Artist" {
+		t.Errorf("Artist = %q, want %q", info.Artist, "Test Artist")
+	}
+	if info.Album != "Test Album" {
+		t.Errorf("Album = %q, want %q", info.Album, "Test Album")
+	}
+	if info.AlbumArtist != "Test Album Artist" {
+		t.Errorf("AlbumArtist = %q, want %q", info.AlbumArtist, "Test Album Artist")
+	}
+	if info.Year != 2024 {
+		t.Errorf("Year = %d, want %d", info.Year, 2024)
+	}
+	if info.Genre != "Rock" {
+		t.Errorf("Genre = %q, want %q", info.Genre, "Rock")
+	}
+	if info.Track != 3 {
+		t.Errorf("Track = %d, want %d", info.Track, 3)
+	}
+	if info.TotalTracks != 12 {
+		t.Errorf("TotalTracks = %d, want %d", info.TotalTracks, 12)
+	}
+	if info.Disc != 1 {
+		t.Errorf("Disc = %d, want %d", info.Disc, 1)
+	}
+	if info.TotalDiscs != 2 {
+		t.Errorf("TotalDiscs = %d, want %d", info.TotalDiscs, 2)
+	}
+}
+
+func TestReadMP3WithID3v2Fallback_AlbumArtistFallsBackToArtist(t *testing.T) {
+	// Create a temporary MP3 file without TPE2 (album artist) frame
+	tmpDir := t.TempDir()
+	mp3Path := filepath.Join(tmpDir, "test.mp3")
+	createMinimalMP3(t, mp3Path)
+
+	// Add tags without album artist
+	tag, err := id3v2.Open(mp3Path, id3v2.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("failed to open MP3 for tagging: %v", err)
+	}
+	tag.SetArtist("Solo Artist")
+	tag.SetAlbum("Album")
+	if err := tag.Save(); err != nil {
+		t.Fatalf("failed to save ID3 tags: %v", err)
+	}
+	tag.Close()
+
+	// Test that album artist falls back to artist
+	info, err := readMP3WithID3v2Fallback(mp3Path)
+	if err != nil {
+		t.Fatalf("readMP3WithID3v2Fallback failed: %v", err)
+	}
+
+	if info.AlbumArtist != "Solo Artist" {
+		t.Errorf("AlbumArtist = %q, want %q (should fall back to Artist)", info.AlbumArtist, "Solo Artist")
+	}
+}
+
+func TestReadMP3WithID3v2Fallback_TitleFallsBackToFilename(t *testing.T) {
+	// Create a temporary MP3 file without title
+	tmpDir := t.TempDir()
+	mp3Path := filepath.Join(tmpDir, "my-song.mp3")
+	createMinimalMP3(t, mp3Path)
+
+	// Add tags without title
+	tag, err := id3v2.Open(mp3Path, id3v2.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("failed to open MP3 for tagging: %v", err)
+	}
+	tag.SetArtist("Artist")
+	tag.SetAlbum("Album")
+	if err := tag.Save(); err != nil {
+		t.Fatalf("failed to save ID3 tags: %v", err)
+	}
+	tag.Close()
+
+	// Test that title falls back to filename
+	info, err := readMP3WithID3v2Fallback(mp3Path)
+	if err != nil {
+		t.Fatalf("readMP3WithID3v2Fallback failed: %v", err)
+	}
+
+	if info.Title != "my-song.mp3" {
+		t.Errorf("Title = %q, want %q (should fall back to filename)", info.Title, "my-song.mp3")
+	}
+}
+
+func TestReadTrackInfo_FallbackOnMalformedUTF16(t *testing.T) {
+	// Create a temporary MP3 file with UTF-16 encoded tags that trigger
+	// the dhowden/tag UTF-16 parsing bug
+	tmpDir := t.TempDir()
+	mp3Path := filepath.Join(tmpDir, "test.mp3")
+	createMinimalMP3(t, mp3Path)
+
+	// Add tags with UTF-16 encoding which triggers the bug in dhowden/tag
+	tag, err := id3v2.Open(mp3Path, id3v2.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("failed to open MP3 for tagging: %v", err)
+	}
+
+	tag.AddTextFrame("TIT2", id3v2.EncodingUTF16, "Test Title UTF16")
+	tag.AddTextFrame("TPE1", id3v2.EncodingUTF16, "Test Artist UTF16")
+	tag.AddTextFrame("TALB", id3v2.EncodingUTF16, "Test Album UTF16")
+	tag.AddTextFrame("TYER", id3v2.EncodingUTF16, "2024")
+	tag.AddTextFrame("TCON", id3v2.EncodingUTF16, "Rock")
+
+	if err := tag.Save(); err != nil {
+		t.Fatalf("failed to save ID3 tags: %v", err)
+	}
+	tag.Close()
+
+	// Test ReadTrackInfo - should succeed via fallback when dhowden/tag fails
+	info, err := ReadTrackInfo(mp3Path)
+	if err != nil {
+		t.Fatalf("ReadTrackInfo failed: %v", err)
+	}
+
+	// Verify we got the metadata via the fallback path
+	if info.Artist == "" {
+		t.Error("Artist should not be empty")
+	}
+	if info.Album == "" {
+		t.Error("Album should not be empty")
+	}
+	if info.Title == "" {
+		t.Error("Title should not be empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds fallback to `bogem/id3v2` library when `dhowden/tag` fails to parse MP3 metadata
- Fixes issue where MP3 files with UTF-16 encoded ID3v2 tags were silently skipped during library scanning
- The `dhowden/tag` library has a bug with certain UTF-16 encoded tags, returning "invalid encoding: expected even number of bytes for UTF-16 encoded text"

## Test plan
- [x] Added unit tests for `parseTrackNumber` helper function
- [x] Added tests for `readMP3WithID3v2Fallback` function
- [x] Added integration test that creates an MP3 with UTF-16 tags that trigger the bug
- [x] Verified test fails without the fix, passes with it
- [x] All existing tests pass
- [x] Linting passes

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)