### PR TITLE
feat: add theme customisation via config.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -67,3 +67,14 @@ default_folder = "~/Music"
 #
 # # Cache
 # cache_ttl_days = 7           # Cache TTL in days
+
+# Theme customisation
+# All colors are optional — omitted values use defaults.
+# Colors must be hex format: #RGB or #RRGGBB
+# [theme]
+# accent = "#a78bfa"      # Primary accent (focused borders, highlights, progress bars)
+# secondary = "#f1a208"   # Secondary accent (radio mode, logo, warnings)
+# text = "#c0c0c0"        # Primary text
+# muted = "#808080"       # Dimmed/secondary text
+# background = "#1a1a1a"  # Panel backgrounds
+# border = "#585858"      # Unfocused borders

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -211,11 +211,11 @@ func (m Model) renderLoading() string {
 	waveLine1 := buildWaveLine(m.LoadingFrame + 2)
 
 	t := styles.T()
-	titleStyle := lipgloss.NewStyle().
+	titleStyle := t.BaseStyle().
 		Foreground(t.Primary).
 		Bold(true)
 
-	waveStyle := lipgloss.NewStyle().
+	waveStyle := t.BaseStyle().
 		Foreground(t.Secondary)
 
 	statusStyle := t.S().Muted.Italic(true)
@@ -306,7 +306,7 @@ and add a music folder to get started.`
 	t := styles.T()
 	messageStyle := t.S().Muted
 
-	hintStyle := lipgloss.NewStyle().
+	hintStyle := t.BaseStyle().
 		Foreground(t.Primary).
 		Bold(true)
 

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -107,7 +107,7 @@ func (m Model) View() string {
 	view = m.Popups.RenderOverlay(view)
 
 	// Ensure view is exactly terminal height (pad or truncate if needed)
-	view = enforceHeight(view, m.Layout.Height())
+	view = enforceHeight(view, m.Layout.Width(), m.Layout.Height())
 
 	// Prepend album art transmission if pending (sent once per track)
 	if m.albumArtPendingTransmit != "" {
@@ -148,22 +148,33 @@ func (m Model) getAlbumArtPlacement() string {
 }
 
 // enforceHeight ensures the view has exactly the specified number of lines.
-func enforceHeight(view string, targetHeight int) string {
+// When the theme has an explicit background, each line is padded to the full
+// terminal width and rendered with the background color.
+func enforceHeight(view string, targetWidth, targetHeight int) string {
 	lines := splitLines(view)
 	currentHeight := len(lines)
 
-	if currentHeight == targetHeight {
-		return view
-	}
-
 	if currentHeight < targetHeight {
-		// Pad with empty lines
 		for i := currentHeight; i < targetHeight; i++ {
 			lines = append(lines, "")
 		}
-	} else {
-		// Truncate (shouldn't normally happen)
+	} else if currentHeight > targetHeight {
 		lines = lines[:targetHeight]
+	}
+
+	// Apply explicit background if set
+	t := styles.T()
+	if t.HasExplicitBackground {
+		bgStyle := lipgloss.NewStyle().
+			Background(t.BgBase).
+			Foreground(t.FgBase)
+		for i, line := range lines {
+			lineWidth := lipgloss.Width(line)
+			if lineWidth < targetWidth {
+				line += strings.Repeat(" ", targetWidth-lineWidth)
+			}
+			lines[i] = bgStyle.Render(line)
+		}
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -330,7 +330,7 @@ and add a music folder to get started.`
 			line := styledLines[msgIdx]
 			lineWidth := lipgloss.Width(line)
 			padLeft := max(0, (innerWidth-lineWidth)/2)
-			contentLines[i] = strings.Repeat(" ", padLeft) + line
+			contentLines[i] = render.EmptyLine(padLeft) + line
 		} else {
 			contentLines[i] = ""
 		}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -355,8 +355,8 @@ func (m Model) renderNotifications() string {
 	innerWidth := m.Layout.Width() - 2 // Account for borders
 
 	// Style: checkmark + message
-	checkStyle := lipgloss.NewStyle().Foreground(t.Primary)
-	msgStyle := lipgloss.NewStyle().Foreground(t.FgBase)
+	checkStyle := t.BaseStyle().Foreground(t.Primary)
+	msgStyle := t.BaseStyle().Foreground(t.FgBase)
 
 	lines := make([]string, 0, len(m.Notifications))
 	for _, n := range m.Notifications {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,9 @@ type Config struct {
 
 	// Desktop notifications
 	Notifications NotificationsConfig `koanf:"notifications"`
+
+	// Theme customisation
+	Theme ThemeConfig `koanf:"theme"`
 }
 
 // SlskdConfig holds all slskd-related configuration.
@@ -105,6 +108,16 @@ type RenameConfig struct {
 	AndToAmpersand    *bool `koanf:"and_to_ampersand"`   // "and" → "&"
 	RemoveFeat        *bool `koanf:"remove_feat"`        // Strip "feat." from titles
 	EllipsisNormalize *bool `koanf:"ellipsis_normalize"` // "..." → "…"
+}
+
+// ThemeConfig holds color customisation settings.
+type ThemeConfig struct {
+	Accent     *string `koanf:"accent"`
+	Secondary  *string `koanf:"secondary"`
+	Text       *string `koanf:"text"`
+	Muted      *string `koanf:"muted"`
+	Background *string `koanf:"background"`
+	Border     *string `koanf:"border"`
 }
 
 // NotificationsConfig holds desktop notification settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -894,3 +894,112 @@ timeout = 3000
 		t.Errorf("expected Timeout=3000, got %d", got.Timeout)
 	}
 }
+
+func TestLoad_ThemeConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	content := `
+[theme]
+accent = "#ff0000"
+secondary = "#00ff00"
+text = "#ffffff"
+muted = "#888888"
+background = "#000000"
+border = "#444444"
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", dir)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("could not change to temp directory: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Theme.Accent == nil || *cfg.Theme.Accent != "#ff0000" {
+		t.Errorf("Theme.Accent = %v, want #ff0000", cfg.Theme.Accent)
+	}
+	if cfg.Theme.Secondary == nil || *cfg.Theme.Secondary != "#00ff00" {
+		t.Errorf("Theme.Secondary = %v, want #00ff00", cfg.Theme.Secondary)
+	}
+	if cfg.Theme.Text == nil || *cfg.Theme.Text != "#ffffff" {
+		t.Errorf("Theme.Text = %v, want #ffffff", cfg.Theme.Text)
+	}
+	if cfg.Theme.Muted == nil || *cfg.Theme.Muted != "#888888" {
+		t.Errorf("Theme.Muted = %v, want #888888", cfg.Theme.Muted)
+	}
+	if cfg.Theme.Background == nil || *cfg.Theme.Background != "#000000" {
+		t.Errorf("Theme.Background = %v, want #000000", cfg.Theme.Background)
+	}
+	if cfg.Theme.Border == nil || *cfg.Theme.Border != "#444444" {
+		t.Errorf("Theme.Border = %v, want #444444", cfg.Theme.Border)
+	}
+}
+
+func TestLoad_ThemeConfigPartial(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	content := `
+[theme]
+accent = "#ff0000"
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", dir)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("could not change to temp directory: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Theme.Accent == nil || *cfg.Theme.Accent != "#ff0000" {
+		t.Errorf("Theme.Accent = %v, want #ff0000", cfg.Theme.Accent)
+	}
+	if cfg.Theme.Secondary != nil {
+		t.Errorf("Theme.Secondary = %v, want nil", cfg.Theme.Secondary)
+	}
+	if cfg.Theme.Text != nil {
+		t.Errorf("Theme.Text = %v, want nil", cfg.Theme.Text)
+	}
+}
+
+func TestLoad_ThemeConfigEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", dir)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("could not change to temp directory: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Theme.Accent != nil {
+		t.Errorf("Theme.Accent = %v, want nil", cfg.Theme.Accent)
+	}
+}

--- a/internal/download/model.go
+++ b/internal/download/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/llehouerou/waves/internal/slskd"
 	"github.com/llehouerou/waves/internal/ui"
 	"github.com/llehouerou/waves/internal/ui/cursor"
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 // FormatFilter represents the audio format filter option.
@@ -117,6 +118,11 @@ func New(slskdURL, slskdAPIKey string, filters FilterConfig, lib *library.Librar
 	ti.Focus()
 	ti.CharLimit = 256
 	ti.Width = 50
+	t := styles.T()
+	ti.TextStyle = t.S().Base
+	ti.PlaceholderStyle = t.S().Subtle
+	ti.PromptStyle = t.S().Base
+	ti.Cursor.Style = t.S().Base
 
 	// Determine format filter
 	formatFilter := FormatBoth

--- a/internal/download/view.go
+++ b/internal/download/view.go
@@ -16,7 +16,7 @@ const (
 )
 
 func selectedStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Foreground(styles.T().Success).
 		Bold(true)
 }
@@ -55,7 +55,7 @@ func stepPendingStyle() lipgloss.Style {
 }
 
 func stepValueStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Foreground(styles.T().Success)
 }
 

--- a/internal/download/view.go
+++ b/internal/download/view.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
@@ -111,7 +112,7 @@ func (m *Model) renderStepIndicator() string {
 	step1Style := m.getStepStyle(1, currentStep)
 	b.WriteString(step1Style.Render("① Artist"))
 	if m.selectedArtist != nil {
-		b.WriteString(" ")
+		b.WriteString(render.EmptyLine(1))
 		b.WriteString(stepValueStyle().Render("✓ " + truncateName(m.selectedArtist.Name, 20)))
 	}
 
@@ -132,7 +133,7 @@ func (m *Model) renderStepIndicator() string {
 		if m.expectedTracks > 0 {
 			info += fmt.Sprintf(" [%d tracks]", m.expectedTracks)
 		}
-		b.WriteString(" ")
+		b.WriteString(render.EmptyLine(1))
 		b.WriteString(stepValueStyle().Render("✓ " + truncateName(info, 40)))
 	}
 

--- a/internal/download/view_release.go
+++ b/internal/download/view_release.go
@@ -91,22 +91,28 @@ func (m *Model) renderReleaseResults() string {
 	for i := start; i < end; i++ {
 		row := &rows[i-start]
 
-		nameCol := row.name + render.EmptyLine(colGap+maxNameW-lipgloss.Width(row.name))
-		tracksCol := row.tracks + render.EmptyLine(colGap+maxTracksW-lipgloss.Width(row.tracks))
-		yearCol := row.year + render.EmptyLine(colGap+maxYearW-lipgloss.Width(row.year))
-		countryCol := row.country + render.EmptyLine(colGap+maxCountryW-lipgloss.Width(row.country))
-		formatCol := row.format
-
-		line := nameCol + tracksCol + yearCol + countryCol + formatCol
+		namePad := colGap + maxNameW - lipgloss.Width(row.name)
+		tracksPad := colGap + maxTracksW - lipgloss.Width(row.tracks)
+		yearPad := colGap + maxYearW - lipgloss.Width(row.year)
+		countryPad := colGap + maxCountryW - lipgloss.Width(row.country)
 
 		if i == cursorPos {
+			line := row.name + strings.Repeat(" ", namePad) +
+				row.tracks + strings.Repeat(" ", tracksPad) +
+				row.year + strings.Repeat(" ", yearPad) +
+				row.country + strings.Repeat(" ", countryPad) +
+				row.format
 			b.WriteString(cursorStyle().Render("> "))
 			b.WriteString(selectedStyle().Render(line))
 		} else {
+			nameCol := row.name + render.EmptyLine(namePad)
+			tracksCol := row.tracks + render.EmptyLine(tracksPad)
+			yearCol := row.year + render.EmptyLine(yearPad)
+			countryCol := row.country + render.EmptyLine(countryPad)
 			b.WriteString(render.EmptyLine(2))
 			styledLine := styles.T().S().Base.Render(nameCol) +
 				typeStyle().Render(tracksCol) +
-				dimStyle().Render(yearCol+countryCol+formatCol)
+				dimStyle().Render(yearCol+countryCol+row.format)
 			b.WriteString(styledLine)
 		}
 		b.WriteString("\n")

--- a/internal/download/view_release.go
+++ b/internal/download/view_release.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/llehouerou/waves/internal/ui/render"
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 // releaseColumns holds the pre-computed column values for a release row.
@@ -88,10 +91,10 @@ func (m *Model) renderReleaseResults() string {
 	for i := start; i < end; i++ {
 		row := &rows[i-start]
 
-		nameCol := row.name + strings.Repeat(" ", colGap+maxNameW-lipgloss.Width(row.name))
-		tracksCol := row.tracks + strings.Repeat(" ", colGap+maxTracksW-lipgloss.Width(row.tracks))
-		yearCol := row.year + strings.Repeat(" ", colGap+maxYearW-lipgloss.Width(row.year))
-		countryCol := row.country + strings.Repeat(" ", colGap+maxCountryW-lipgloss.Width(row.country))
+		nameCol := row.name + render.EmptyLine(colGap+maxNameW-lipgloss.Width(row.name))
+		tracksCol := row.tracks + render.EmptyLine(colGap+maxTracksW-lipgloss.Width(row.tracks))
+		yearCol := row.year + render.EmptyLine(colGap+maxYearW-lipgloss.Width(row.year))
+		countryCol := row.country + render.EmptyLine(colGap+maxCountryW-lipgloss.Width(row.country))
 		formatCol := row.format
 
 		line := nameCol + tracksCol + yearCol + countryCol + formatCol
@@ -100,8 +103,8 @@ func (m *Model) renderReleaseResults() string {
 			b.WriteString(cursorStyle().Render("> "))
 			b.WriteString(selectedStyle().Render(line))
 		} else {
-			b.WriteString("  ")
-			styledLine := nameCol +
+			b.WriteString(render.EmptyLine(2))
+			styledLine := styles.T().S().Base.Render(nameCol) +
 				typeStyle().Render(tracksCol) +
 				dimStyle().Render(yearCol+countryCol+formatCol)
 			b.WriteString(styledLine)

--- a/internal/download/view_releasegroup.go
+++ b/internal/download/view_releasegroup.go
@@ -95,23 +95,22 @@ func (m *Model) renderReleaseGroupResults() string {
 	for i := start; i < end; i++ {
 		row := &rows[i-start]
 
-		// Build the line with aligned columns.
-		nameCol := row.name + render.EmptyLine(colGap+maxNameW-lipgloss.Width(row.name))
-		yearCol := row.year + render.EmptyLine(colGap+maxYearW-lipgloss.Width(row.year))
-		typeCol := row.typeLabel
-
-		line := nameCol + yearCol + typeCol
+		// Build columns with plain padding (for cursor/selected) and styled padding (for normal).
+		namePad := colGap + maxNameW - lipgloss.Width(row.name)
+		yearPad := colGap + maxYearW - lipgloss.Width(row.year)
 
 		if i == cursorPos {
+			line := row.name + strings.Repeat(" ", namePad) + row.year + strings.Repeat(" ", yearPad) + row.typeLabel
 			b.WriteString(cursorStyle().Render("> "))
 			b.WriteString(selectedStyle().Render(line))
 		} else {
+			nameCol := row.name + render.EmptyLine(namePad)
+			yearCol := row.year + render.EmptyLine(yearPad)
 			b.WriteString(render.EmptyLine(2))
 			if row.inLibrary {
-				b.WriteString(dimStyle().Render(line))
+				b.WriteString(dimStyle().Render(row.name + strings.Repeat(" ", namePad) + row.year + strings.Repeat(" ", yearPad) + row.typeLabel))
 			} else {
-				// Apply type styling only to the type column.
-				styledLine := styles.T().S().Base.Render(nameCol) + dimStyle().Render(yearCol) + typeStyle().Render(typeCol)
+				styledLine := styles.T().S().Base.Render(nameCol) + dimStyle().Render(yearCol) + typeStyle().Render(row.typeLabel)
 				b.WriteString(styledLine)
 			}
 		}

--- a/internal/download/view_releasegroup.go
+++ b/internal/download/view_releasegroup.go
@@ -6,6 +6,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/llehouerou/waves/internal/icons"
+	"github.com/llehouerou/waves/internal/ui/render"
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 // releaseGroupColumns holds the pre-computed column values for a release group row.
@@ -94,8 +96,8 @@ func (m *Model) renderReleaseGroupResults() string {
 		row := &rows[i-start]
 
 		// Build the line with aligned columns.
-		nameCol := row.name + strings.Repeat(" ", colGap+maxNameW-lipgloss.Width(row.name))
-		yearCol := row.year + strings.Repeat(" ", colGap+maxYearW-lipgloss.Width(row.year))
+		nameCol := row.name + render.EmptyLine(colGap+maxNameW-lipgloss.Width(row.name))
+		yearCol := row.year + render.EmptyLine(colGap+maxYearW-lipgloss.Width(row.year))
 		typeCol := row.typeLabel
 
 		line := nameCol + yearCol + typeCol
@@ -104,12 +106,12 @@ func (m *Model) renderReleaseGroupResults() string {
 			b.WriteString(cursorStyle().Render("> "))
 			b.WriteString(selectedStyle().Render(line))
 		} else {
-			b.WriteString("  ")
+			b.WriteString(render.EmptyLine(2))
 			if row.inLibrary {
 				b.WriteString(dimStyle().Render(line))
 			} else {
 				// Apply type styling only to the type column.
-				styledLine := nameCol + dimStyle().Render(yearCol) + typeStyle().Render(typeCol)
+				styledLine := styles.T().S().Base.Render(nameCol) + dimStyle().Render(yearCol) + typeStyle().Render(typeCol)
 				b.WriteString(styledLine)
 			}
 		}

--- a/internal/download/view_search.go
+++ b/internal/download/view_search.go
@@ -96,22 +96,20 @@ func (m *Model) renderArtistResults() string {
 		if row.disamb != "" {
 			combined += " " + row.disamb
 		}
-		pad := render.EmptyLine(colGap + maxCombinedW - lipgloss.Width(combined))
-
-		typeCol := row.typeCol + render.EmptyLine(colGap+maxTypeW-lipgloss.Width(row.typeCol))
-		yearsCol := row.years
+		combinedPad := colGap + maxCombinedW - lipgloss.Width(combined)
+		typePad := colGap + maxTypeW - lipgloss.Width(row.typeCol)
 
 		base := styles.T().S().Base
 		if i == cursorPos {
+			// Build plain line for cursor styling
+			line := combined + strings.Repeat(" ", combinedPad) +
+				row.typeCol + strings.Repeat(" ", typePad) +
+				fmt.Sprintf("%-*s%s", maxCountryW+colGap, row.country, row.years)
 			b.WriteString(cursorStyle().Render("> "))
-			b.WriteString(selectedStyle().Render(row.name))
-			if row.disamb != "" {
-				b.WriteString(render.EmptyLine(1) + dimStyle().Render(row.disamb))
-			}
-			b.WriteString(pad)
-			b.WriteString(typeStyle().Render(typeCol))
-			b.WriteString(dimStyle().Render(fmt.Sprintf("%-*s%s", maxCountryW+colGap, row.country, yearsCol)))
+			b.WriteString(selectedStyle().Render(line))
 		} else {
+			pad := render.EmptyLine(combinedPad)
+			typeCol := row.typeCol + render.EmptyLine(typePad)
 			b.WriteString(render.EmptyLine(2))
 			// Name in normal style, disamb in dim.
 			styledCombined := base.Render(row.name)
@@ -122,7 +120,7 @@ func (m *Model) renderArtistResults() string {
 
 			b.WriteString(styledCombined)
 			b.WriteString(typeStyle().Render(typeCol))
-			b.WriteString(dimStyle().Render(fmt.Sprintf("%-*s%s", maxCountryW+colGap, row.country, yearsCol)))
+			b.WriteString(dimStyle().Render(fmt.Sprintf("%-*s%s", maxCountryW+colGap, row.country, row.years)))
 		}
 		b.WriteString("\n")
 	}

--- a/internal/download/view_search.go
+++ b/internal/download/view_search.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/llehouerou/waves/internal/ui/render"
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 // renderSearchSection renders the search input.
@@ -93,26 +96,27 @@ func (m *Model) renderArtistResults() string {
 		if row.disamb != "" {
 			combined += " " + row.disamb
 		}
-		pad := strings.Repeat(" ", colGap+maxCombinedW-lipgloss.Width(combined))
+		pad := render.EmptyLine(colGap + maxCombinedW - lipgloss.Width(combined))
 
-		typeCol := row.typeCol + strings.Repeat(" ", colGap+maxTypeW-lipgloss.Width(row.typeCol))
+		typeCol := row.typeCol + render.EmptyLine(colGap+maxTypeW-lipgloss.Width(row.typeCol))
 		yearsCol := row.years
 
+		base := styles.T().S().Base
 		if i == cursorPos {
 			b.WriteString(cursorStyle().Render("> "))
 			b.WriteString(selectedStyle().Render(row.name))
 			if row.disamb != "" {
-				b.WriteString(" " + dimStyle().Render(row.disamb))
+				b.WriteString(render.EmptyLine(1) + dimStyle().Render(row.disamb))
 			}
 			b.WriteString(pad)
 			b.WriteString(typeStyle().Render(typeCol))
 			b.WriteString(dimStyle().Render(fmt.Sprintf("%-*s%s", maxCountryW+colGap, row.country, yearsCol)))
 		} else {
-			b.WriteString("  ")
+			b.WriteString(render.EmptyLine(2))
 			// Name in normal style, disamb in dim.
-			styledCombined := row.name
+			styledCombined := base.Render(row.name)
 			if row.disamb != "" {
-				styledCombined += " " + dimStyle().Render(row.disamb)
+				styledCombined += render.EmptyLine(1) + dimStyle().Render(row.disamb)
 			}
 			styledCombined += pad
 

--- a/internal/download/view_slskd.go
+++ b/internal/download/view_slskd.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/llehouerou/waves/internal/ui/render"
 )
 
 // renderSlskdResults renders the slskd search results as a table.
@@ -67,7 +69,7 @@ func (m *Model) renderSlskdResults() string {
 
 	b.WriteString(dimStyle().Render(header))
 	b.WriteString("\n")
-	b.WriteString(dimStyle().Render(strings.Repeat("─", separatorWidth)))
+	b.WriteString(render.Separator(separatorWidth))
 	b.WriteString("\n")
 
 	maxVisible := m.slskdListHeight()

--- a/internal/download/view_slskd.go
+++ b/internal/download/view_slskd.go
@@ -119,8 +119,7 @@ func (m *Model) renderSlskdResults() string {
 			b.WriteString(cursorStyle().Render("> "))
 			b.WriteString(selectedStyle().Render(row))
 		} else {
-			b.WriteString("  ")
-			b.WriteString(row)
+			b.WriteString(dimStyle().Render("  " + row))
 		}
 		b.WriteString("\n")
 	}

--- a/internal/importer/popup/view.go
+++ b/internal/importer/popup/view.go
@@ -168,7 +168,7 @@ func (m *Model) renderTagPreview() string {
 		headerStyle().Render("Tag Changes Preview"),
 		"",
 		dimStyle().Render(header),
-		dimStyle().Render(strings.Repeat("-", innerWidth)),
+		render.Separator(innerWidth),
 	}
 
 	// Tag diffs
@@ -305,7 +305,7 @@ func (m *Model) renderPathPreview() string {
 	endIdx := min(startIdx+maxFiles, len(m.filePaths))
 
 	if compact {
-		lines = append(lines, dimStyle().Render(strings.Repeat("-", innerWidth)))
+		lines = append(lines, render.Separator(innerWidth))
 		lines = append(lines, m.renderCompactFilePaths(startIdx, endIdx, innerWidth)...)
 	} else {
 		// Wide layout: single line per file
@@ -321,7 +321,7 @@ func (m *Model) renderPathPreview() string {
 			newWidth, "New Path")
 		lines = append(lines,
 			dimStyle().Render(header),
-			dimStyle().Render(strings.Repeat("-", innerWidth)),
+			render.Separator(innerWidth),
 		)
 
 		for i := startIdx; i < endIdx; i++ {

--- a/internal/retag/view.go
+++ b/internal/retag/view.go
@@ -396,7 +396,7 @@ func (m *Model) renderTagPreview() string {
 		headerStyle().Render("Tag Changes Preview"),
 		"",
 		dimStyle().Render(header),
-		dimStyle().Render(strings.Repeat("-", innerWidth)),
+		render.Separator(innerWidth),
 	)
 
 	// Tag diffs

--- a/internal/search/view.go
+++ b/internal/search/view.go
@@ -6,13 +6,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/llehouerou/waves/internal/ui/popup"
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 const maxVisibleResults = 20
 
 func popupStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(styles.T().Border)
 }
@@ -108,7 +109,7 @@ func (m Model) formatResultLine(item Item, innerW int, isCursor bool) string {
 
 	// Build line with left-aligned name and right-aligned path
 	gap := max(1, availW-lipgloss.Width(left)-rightW)
-	return prefix + left + strings.Repeat(" ", gap) + dimStyle().Render(right)
+	return prefix + left + render.EmptyLine(gap) + dimStyle().Render(right)
 }
 
 // View implements tea.Model.
@@ -125,7 +126,7 @@ func (m Model) View() string {
 	input := inputStyle().Render(prompt + m.query)
 
 	// Separator
-	separator := strings.Repeat("─", innerW)
+	separator := render.Separator(innerW)
 
 	// Results
 	visible := m.visibleHeight()

--- a/internal/search/view.go
+++ b/internal/search/view.go
@@ -13,9 +13,14 @@ import (
 const maxVisibleResults = 20
 
 func popupStyle() lipgloss.Style {
-	return styles.T().BaseStyle().
+	t := styles.T()
+	s := t.BaseStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(styles.T().Border)
+		BorderForeground(t.Border)
+	if t.HasExplicitBackground {
+		s = s.BorderBackground(t.BgBase)
+	}
+	return s
 }
 
 func inputStyle() lipgloss.Style {

--- a/internal/ui/albumview/grouping_popup.go
+++ b/internal/ui/albumview/grouping_popup.go
@@ -44,7 +44,7 @@ func gpHintStyle() lipgloss.Style {
 }
 
 func gpOrderStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(styles.T().Secondary)
+	return styles.T().BaseStyle().Foreground(styles.T().Secondary)
 }
 
 // optionRow represents which option row is selected in the options section.

--- a/internal/ui/albumview/presets_popup.go
+++ b/internal/ui/albumview/presets_popup.go
@@ -213,7 +213,7 @@ func (p *PresetsPopup) viewListMode() string {
 
 			// Build description
 			desc := p.formatPresetDescription(preset.Settings)
-			line := prefix + ppPresetStyle().Render(preset.Name) + " " + ppHintStyle().Render("("+desc+")")
+			line := prefix + ppPresetStyle().Render(preset.Name) + ppPresetStyle().Render(" ") + ppHintStyle().Render("("+desc+")")
 
 			if i == p.cursor {
 				line = ppCursorStyle().Render(line)

--- a/internal/ui/albumview/sorting_popup.go
+++ b/internal/ui/albumview/sorting_popup.go
@@ -35,7 +35,7 @@ func spHintStyle() lipgloss.Style {
 }
 
 func spOrderStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(styles.T().Secondary)
+	return styles.T().BaseStyle().Foreground(styles.T().Secondary)
 }
 
 func spAscStyle() lipgloss.Style {

--- a/internal/ui/albumview/view.go
+++ b/internal/ui/albumview/view.go
@@ -282,8 +282,8 @@ func (m Model) renderAlbumLine(album *library.AlbumEntry, width int, isCursor bo
 	indent := render.EmptyLine(len(albumIndent))
 
 	if isCursor {
-		// When cursor, use cursor background for the whole line
-		line := albumIndent + artistCol + " " + albumCol + yearCol
+		// When cursor, use cursor background for the whole line with selection indicator
+		line := " > " + artistCol + " " + albumCol + yearCol
 		return cursorStyle().Render(line)
 	}
 

--- a/internal/ui/albumview/view.go
+++ b/internal/ui/albumview/view.go
@@ -100,6 +100,8 @@ func (m Model) View() string {
 // renderHeader renders the view header with current settings and key bindings.
 // At narrow widths, the header wraps to multiple lines.
 func (m Model) renderHeader(width int) string {
+	sp := render.EmptyLine(1)
+
 	title := headerTitleStyle().Render("Albums")
 	sep := headerSepStyle().Render(" │ ")
 
@@ -107,22 +109,22 @@ func (m Model) renderHeader(width int) string {
 	groupKey := headerKeyStyle().Render("[og]")
 	groupLabel := headerKeyStyle().Render("Group:")
 	groupValue := m.groupValueLabel()
-	groupSection := groupKey + " " + groupLabel + " " + headerValueStyle().Render(groupValue)
+	groupSection := groupKey + sp + groupLabel + sp + headerValueStyle().Render(groupValue)
 
 	// Sort section: [os] Sort: Original Date ↓
 	sortKey := headerKeyStyle().Render("[os]")
 	sortLabel := headerKeyStyle().Render("Sort:")
 	sortValue := m.sortValueLabel()
-	sortSection := sortKey + " " + sortLabel + " " + headerValueStyle().Render(sortValue)
+	sortSection := sortKey + sp + sortLabel + sp + headerValueStyle().Render(sortValue)
 
 	// Preset section: [op] Preset: name or (none)
 	presetKey := headerKeyStyle().Render("[op]")
 	presetLabel := headerKeyStyle().Render("Preset:")
 	var presetSection string
 	if m.settings.PresetName != "" {
-		presetSection = presetKey + " " + presetLabel + " " + headerValueStyle().Render(m.settings.PresetName)
+		presetSection = presetKey + sp + presetLabel + sp + headerValueStyle().Render(m.settings.PresetName)
 	} else {
-		presetSection = presetKey + " " + presetLabel
+		presetSection = presetKey + sp + presetLabel
 	}
 
 	// Build header sections that we'll wrap as needed
@@ -145,7 +147,7 @@ func (m Model) renderHeader(width int) string {
 		if currentWidth > 0 && currentWidth+addWidth > width {
 			// Wrap to new line - pad current line first
 			if currentWidth < width {
-				currentLine += strings.Repeat(" ", width-currentWidth)
+				currentLine += render.EmptyLine(width - currentWidth)
 			}
 			lines = append(lines, currentLine)
 			currentLine = section
@@ -163,7 +165,7 @@ func (m Model) renderHeader(width int) string {
 		// If this is the last section, finalize the line
 		if i == len(sections)-1 {
 			if currentWidth < width {
-				currentLine += strings.Repeat(" ", width-currentWidth)
+				currentLine += render.EmptyLine(width - currentWidth)
 			}
 			lines = append(lines, currentLine)
 		}
@@ -277,6 +279,8 @@ func (m Model) renderAlbumLine(album *library.AlbumEntry, width int, isCursor bo
 	}
 
 	// Apply styles
+	indent := render.EmptyLine(len(albumIndent))
+
 	if isCursor {
 		// When cursor, use cursor background for the whole line
 		line := albumIndent + artistCol + " " + albumCol + yearCol
@@ -285,9 +289,9 @@ func (m Model) renderAlbumLine(album *library.AlbumEntry, width int, isCursor bo
 
 	// Normal rendering with different colors per column
 	if showYear {
-		return albumIndent + artistStyle().Render(artistCol) + " " + albumNameStyle().Render(albumCol) + yearStyle().Render(yearCol)
+		return indent + artistStyle().Render(artistCol) + render.EmptyLine(1) + albumNameStyle().Render(albumCol) + yearStyle().Render(yearCol)
 	}
-	return albumIndent + artistStyle().Render(artistCol) + " " + albumNameStyle().Render(albumCol)
+	return indent + artistStyle().Render(artistCol) + render.EmptyLine(1) + albumNameStyle().Render(albumCol)
 }
 
 // isGroupedByArtist returns true if any grouping level is by artist.

--- a/internal/ui/albumview/view.go
+++ b/internal/ui/albumview/view.go
@@ -23,9 +23,9 @@ const (
 func groupHeaderStyles() []lipgloss.Style {
 	t := styles.T()
 	return []lipgloss.Style{
-		lipgloss.NewStyle().Bold(true).Foreground(t.Primary),   // Level 0: Primary
-		lipgloss.NewStyle().Bold(true).Foreground(t.Secondary), // Level 1: Secondary
-		lipgloss.NewStyle().Bold(true).Foreground(t.Success),   // Level 2: Success
+		t.BaseStyle().Bold(true).Foreground(t.Primary),   // Level 0: Primary
+		t.BaseStyle().Bold(true).Foreground(t.Secondary), // Level 1: Secondary
+		t.BaseStyle().Bold(true).Foreground(t.Success),   // Level 2: Success
 	}
 }
 

--- a/internal/ui/confirm/confirm.go
+++ b/internal/ui/confirm/confirm.go
@@ -14,7 +14,7 @@ import (
 var _ popup.Popup = (*Model)(nil)
 
 func titleStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Bold(true).
 		Foreground(styles.T().Primary)
 }
@@ -159,7 +159,7 @@ func optionStyle() lipgloss.Style {
 }
 
 func selectedOptionStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Foreground(styles.T().Primary).
 		Bold(true)
 }

--- a/internal/ui/downloads/view.go
+++ b/internal/ui/downloads/view.go
@@ -203,7 +203,7 @@ func (m Model) renderEmptyState(innerWidth, listHeight int) string {
 
 	for i := range lines {
 		if i == centerLine {
-			centered := lipgloss.NewStyle().Width(innerWidth).Align(lipgloss.Center).Render(emptyMsg)
+			centered := styles.T().BaseStyle().Width(innerWidth).Align(lipgloss.Center).Render(emptyMsg)
 			lines[i] = emptyStyle().Render(centered)
 		} else {
 			lines[i] = render.EmptyLine(innerWidth)
@@ -233,7 +233,7 @@ func (m Model) renderNotConfigured(innerWidth, listHeight int) string {
 		lineIdx := i - startLine
 		if lineIdx >= 0 && lineIdx < len(configLines) {
 			text := configLines[lineIdx]
-			centered := lipgloss.NewStyle().Width(innerWidth).Align(lipgloss.Center).Render(text)
+			centered := styles.T().BaseStyle().Width(innerWidth).Align(lipgloss.Center).Render(text)
 			lines[i] = emptyStyle().Render(centered)
 		} else {
 			lines[i] = render.EmptyLine(innerWidth)
@@ -317,7 +317,7 @@ func (m Model) renderDownloadLine(d *downloads.Download, idx, width int) string 
 	albumInfo = render.Truncate(albumInfo, contentWidth)
 	albumInfo = render.Pad(albumInfo, contentWidth)
 
-	line := prefix + albumInfo + " " + statusStyle.Render(statusText)
+	line := prefix + albumInfo + render.EmptyLine(1) + statusStyle.Render(statusText)
 
 	// Apply cursor style if selected
 	if isCursor {

--- a/internal/ui/export/view.go
+++ b/internal/ui/export/view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/llehouerou/waves/internal/export"
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
@@ -52,18 +53,13 @@ func (m Model) viewSelectTarget() string {
 
 	// What we're exporting
 	if m.albumName != "" {
-		fmt.Fprintf(&b, "  %s\n", m.albumName)
+		b.WriteString(render.EmptyLine(2) + dimStyle.Render(m.albumName) + "\n")
 	}
-	fmt.Fprintf(&b, "  %d tracks\n\n", len(m.tracks))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render(fmt.Sprintf("%d tracks", len(m.tracks))) + "\n\n")
 
 	// Target list
-	b.WriteString("  Target:\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Target:") + "\n")
 	for i, target := range m.targets {
-		prefix := "    "
-		if i == m.selectedIdx {
-			prefix = "  ▸ "
-		}
-
 		connected := m.isTargetConnected(target)
 		line := target.Name
 		if !connected {
@@ -71,19 +67,20 @@ func (m Model) viewSelectTarget() string {
 		}
 
 		if i == m.selectedIdx {
-			line = selectedStyle.Render(line)
+			if connected {
+				line = selectedStyle.Render(line)
+			}
+			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ ") + line + "\n")
+		} else {
+			b.WriteString(render.EmptyLine(4) + line + "\n")
 		}
-
-		b.WriteString(prefix + line + "\n")
 	}
 
 	// New target option
-	newTargetLine := "+ New target..."
 	if m.selectedIdx == len(m.targets) {
-		newTargetLine = selectedStyle.Render(newTargetLine)
-		b.WriteString("  ▸ " + newTargetLine + "\n")
+		b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ + New target...") + "\n")
 	} else {
-		b.WriteString("    " + newTargetLine + "\n")
+		b.WriteString(render.EmptyLine(4) + dimStyle.Render("+ New target...") + "\n")
 	}
 
 	// FLAC conversion toggle
@@ -93,13 +90,12 @@ func (m Model) viewSelectTarget() string {
 		if m.convertFLAC {
 			checkbox = "[x]"
 		}
-		fmt.Fprintf(&b, "  %s Convert FLAC to MP3 (%d files, 320kbps)\n",
-			checkbox, m.flacCount)
+		b.WriteString(render.EmptyLine(2) + dimStyle.Render(fmt.Sprintf("%s Convert FLAC to MP3 (%d files, 320kbps)", checkbox, m.flacCount)) + "\n")
 	}
 
 	// Help
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  ↑↓ navigate  enter confirm  r rename  d delete  space toggle  esc cancel"))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓ navigate  enter confirm  r rename  d delete  space toggle  esc cancel"))
 
 	return b.String()
 }
@@ -112,34 +108,29 @@ func (m Model) viewNewTarget() string {
 
 	// Show volumes
 	for i, vol := range m.volumes {
-		prefix := "    "
-		if i == m.volumeIdx {
-			prefix = "  ▸ "
-		}
-
 		line := vol.String()
 		if i == m.volumeIdx {
 			line = selectedStyle.Render(line)
+			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ ") + line + "\n")
+		} else {
+			b.WriteString(render.EmptyLine(4) + dimStyle.Render(line) + "\n")
 		}
-		b.WriteString(prefix + line + "\n")
 	}
 
 	// Custom folder option (always available)
-	customFolderLine := "📁 Custom folder..."
 	if m.volumeIdx == len(m.volumes) {
-		customFolderLine = selectedStyle.Render(customFolderLine)
-		b.WriteString("  ▸ " + customFolderLine + "\n")
+		b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ 📁 Custom folder...") + "\n")
 	} else {
-		b.WriteString("    " + customFolderLine + "\n")
+		b.WriteString(render.EmptyLine(4) + dimStyle.Render("📁 Custom folder...") + "\n")
 	}
 
 	if len(m.volumes) == 0 {
 		b.WriteString("\n")
-		b.WriteString(dimStyle.Render("  No removable devices detected.") + "\n")
+		b.WriteString(render.EmptyLine(2) + dimStyle.Render("No removable devices detected.") + "\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  ↑↓ navigate  enter select  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓ navigate  enter select  esc back"))
 
 	return b.String()
 }
@@ -155,8 +146,8 @@ func (m Model) viewNewTargetFolder() string {
 	if label == "" {
 		label = m.newTarget.Name
 	}
-	fmt.Fprintf(&b, "  Device: %s\n", label)
-	fmt.Fprintf(&b, "  Path: %s\n\n", m.currentPath)
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Device: "+label) + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Path: "+m.currentPath) + "\n\n")
 
 	// Directory listing
 	hasParent := m.currentPath != "/"
@@ -164,35 +155,31 @@ func (m Model) viewNewTargetFolder() string {
 
 	// Show ".." if not at root
 	if hasParent {
-		prefix := "    "
-		line := ".."
 		if m.dirIdx == idx {
-			prefix = "  ▸ "
-			line = selectedStyle.Render(line)
+			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ ..") + "\n")
+		} else {
+			b.WriteString(render.EmptyLine(4) + dimStyle.Render("..") + "\n")
 		}
-		b.WriteString(prefix + line + "\n")
 		idx++
 	}
 
 	// Show directories
 	for _, dir := range m.directories {
-		prefix := "    "
-		line := dir
 		if m.dirIdx == idx {
-			prefix = "  ▸ "
-			line = selectedStyle.Render(line)
+			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ "+dir) + "\n")
+		} else {
+			b.WriteString(render.EmptyLine(4) + dimStyle.Render(dir) + "\n")
 		}
-		b.WriteString(prefix + line + "\n")
 		idx++
 	}
 
 	// Empty directory message
 	if len(m.directories) == 0 && !hasParent {
-		b.WriteString(dimStyle.Render("  (empty)") + "\n")
+		b.WriteString(render.EmptyLine(2) + dimStyle.Render("(empty)") + "\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  ↑↓ navigate  enter open  space select  backspace up  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓ navigate  enter open  space select  backspace up  esc back"))
 
 	return b.String()
 }
@@ -203,10 +190,10 @@ func (m Model) viewNewTargetConfig() string {
 	b.WriteString(titleStyle.Render("Configure Target"))
 	b.WriteString("\n\n")
 
-	fmt.Fprintf(&b, "  Device: %s\n", m.newTarget.DeviceLabel)
-	fmt.Fprintf(&b, "  Folder: %s\n\n", m.newTarget.Subfolder)
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Device: "+m.newTarget.DeviceLabel) + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder: "+m.newTarget.Subfolder) + "\n\n")
 
-	b.WriteString("  Folder structure:\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder structure:") + "\n")
 	structures := []struct {
 		fs    export.FolderStructure
 		label string
@@ -217,19 +204,16 @@ func (m Model) viewNewTargetConfig() string {
 	}
 
 	for i, s := range structures {
-		prefix := "    "
-		if i == m.structureIdx {
-			prefix = "  ▸ "
-		}
 		line := fmt.Sprintf("[%d] %s", i+1, s.label)
 		if i == m.structureIdx {
-			line = selectedStyle.Render(line)
+			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ "+line) + "\n")
+		} else {
+			b.WriteString(render.EmptyLine(4) + dimStyle.Render(line) + "\n")
 		}
-		b.WriteString(prefix + line + "\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  ↑↓/1-3 select  enter save  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓/1-3 select  enter save  esc back"))
 
 	return b.String()
 }
@@ -241,11 +225,11 @@ func (m Model) viewRenameTarget() string {
 	b.WriteString("\n\n")
 
 	// Show current name with cursor
-	b.WriteString("  New name:\n")
-	b.WriteString("  " + selectedStyle.Render(m.renameInput+"▏") + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("New name:") + "\n")
+	b.WriteString(render.EmptyLine(2) + selectedStyle.Render(m.renameInput+"▏") + "\n")
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  enter confirm  esc cancel"))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("enter confirm  esc cancel"))
 
 	return b.String()
 }
@@ -256,11 +240,11 @@ func (m Model) viewCustomFolder() string {
 	b.WriteString(titleStyle.Render("Custom Folder"))
 	b.WriteString("\n\n")
 
-	b.WriteString("  Enter folder path:\n")
-	b.WriteString("  " + selectedStyle.Render(m.customFolderInput+"▏") + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Enter folder path:") + "\n")
+	b.WriteString(render.EmptyLine(2) + selectedStyle.Render(m.customFolderInput+"▏") + "\n")
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  enter confirm  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("enter confirm  esc back"))
 
 	return b.String()
 }
@@ -271,9 +255,9 @@ func (m Model) viewCustomFolderConfig() string {
 	b.WriteString(titleStyle.Render("Configure Target"))
 	b.WriteString("\n\n")
 
-	fmt.Fprintf(&b, "  Folder: %s\n\n", m.newTarget.Subfolder)
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder: "+m.newTarget.Subfolder) + "\n\n")
 
-	b.WriteString("  Folder structure:\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder structure:") + "\n")
 	structures := []struct {
 		fs    export.FolderStructure
 		label string
@@ -284,19 +268,16 @@ func (m Model) viewCustomFolderConfig() string {
 	}
 
 	for i, s := range structures {
-		prefix := "    "
-		if i == m.structureIdx {
-			prefix = "  ▸ "
-		}
 		line := fmt.Sprintf("[%d] %s", i+1, s.label)
 		if i == m.structureIdx {
-			line = selectedStyle.Render(line)
+			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ "+line) + "\n")
+		} else {
+			b.WriteString(render.EmptyLine(4) + dimStyle.Render(line) + "\n")
 		}
-		b.WriteString(prefix + line + "\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  ↑↓/1-3 select  enter save  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓/1-3 select  enter save  esc back"))
 
 	return b.String()
 }

--- a/internal/ui/export/view.go
+++ b/internal/ui/export/view.go
@@ -4,22 +4,20 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
-
 	"github.com/llehouerou/waves/internal/export"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 var (
-	titleStyle = lipgloss.NewStyle().
+	titleStyle = styles.T().BaseStyle().
 			Bold(true).
 			Foreground(styles.T().Primary)
 
-	selectedStyle = lipgloss.NewStyle().
+	selectedStyle = styles.T().BaseStyle().
 			Foreground(styles.T().Primary).
 			Bold(true)
 
-	dimStyle = lipgloss.NewStyle().
+	dimStyle = styles.T().BaseStyle().
 			Foreground(styles.T().FgMuted)
 )
 

--- a/internal/ui/export/view.go
+++ b/internal/ui/export/view.go
@@ -4,23 +4,27 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/llehouerou/waves/internal/export"
 	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
-var (
-	titleStyle = styles.T().BaseStyle().
-			Bold(true).
-			Foreground(styles.T().Primary)
+func titleStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Bold(true).
+		Foreground(styles.T().Primary)
+}
 
-	selectedStyle = styles.T().BaseStyle().
-			Foreground(styles.T().Primary).
-			Bold(true)
+func selectedStyle() lipgloss.Style {
+	return styles.T().S().Cursor
+}
 
-	dimStyle = styles.T().BaseStyle().
-			Foreground(styles.T().FgMuted)
-)
+func dimStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Foreground(styles.T().FgMuted)
+}
 
 // View renders the popup.
 func (m Model) View() string {
@@ -48,29 +52,29 @@ func (m Model) viewSelectTarget() string {
 	var b strings.Builder
 
 	// Header
-	b.WriteString(titleStyle.Render("Export"))
+	b.WriteString(titleStyle().Render("Export"))
 	b.WriteString("\n\n")
 
 	// What we're exporting
 	if m.albumName != "" {
-		b.WriteString(render.EmptyLine(2) + dimStyle.Render(m.albumName) + "\n")
+		b.WriteString(render.EmptyLine(2) + dimStyle().Render(m.albumName) + "\n")
 	}
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render(fmt.Sprintf("%d tracks", len(m.tracks))) + "\n\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render(fmt.Sprintf("%d tracks", len(m.tracks))) + "\n\n")
 
 	// Target list
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Target:") + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Target:") + "\n")
 	for i, target := range m.targets {
 		connected := m.isTargetConnected(target)
 		line := target.Name
 		if !connected {
-			line = dimStyle.Render(line + " (not connected)")
+			line = dimStyle().Render(line + " (not connected)")
 		}
 
 		if i == m.selectedIdx {
 			if connected {
-				line = selectedStyle.Render(line)
+				line = selectedStyle().Render(line)
 			}
-			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ ") + line + "\n")
+			b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> ") + line + "\n")
 		} else {
 			b.WriteString(render.EmptyLine(4) + line + "\n")
 		}
@@ -78,9 +82,9 @@ func (m Model) viewSelectTarget() string {
 
 	// New target option
 	if m.selectedIdx == len(m.targets) {
-		b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ + New target...") + "\n")
+		b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> + New target...") + "\n")
 	} else {
-		b.WriteString(render.EmptyLine(4) + dimStyle.Render("+ New target...") + "\n")
+		b.WriteString(render.EmptyLine(4) + dimStyle().Render("+ New target...") + "\n")
 	}
 
 	// FLAC conversion toggle
@@ -90,12 +94,12 @@ func (m Model) viewSelectTarget() string {
 		if m.convertFLAC {
 			checkbox = "[x]"
 		}
-		b.WriteString(render.EmptyLine(2) + dimStyle.Render(fmt.Sprintf("%s Convert FLAC to MP3 (%d files, 320kbps)", checkbox, m.flacCount)) + "\n")
+		b.WriteString(render.EmptyLine(2) + dimStyle().Render(fmt.Sprintf("%s Convert FLAC to MP3 (%d files, 320kbps)", checkbox, m.flacCount)) + "\n")
 	}
 
 	// Help
 	b.WriteString("\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓ navigate  enter confirm  r rename  d delete  space toggle  esc cancel"))
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("↑↓ navigate  enter confirm  r rename  d delete  space toggle  esc cancel"))
 
 	return b.String()
 }
@@ -103,34 +107,34 @@ func (m Model) viewSelectTarget() string {
 func (m Model) viewNewTarget() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("Select Device"))
+	b.WriteString(titleStyle().Render("Select Device"))
 	b.WriteString("\n\n")
 
 	// Show volumes
 	for i, vol := range m.volumes {
 		line := vol.String()
 		if i == m.volumeIdx {
-			line = selectedStyle.Render(line)
-			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ ") + line + "\n")
+			line = selectedStyle().Render(line)
+			b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> ") + line + "\n")
 		} else {
-			b.WriteString(render.EmptyLine(4) + dimStyle.Render(line) + "\n")
+			b.WriteString(render.EmptyLine(4) + dimStyle().Render(line) + "\n")
 		}
 	}
 
 	// Custom folder option (always available)
 	if m.volumeIdx == len(m.volumes) {
-		b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ 📁 Custom folder...") + "\n")
+		b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> 📁 Custom folder...") + "\n")
 	} else {
-		b.WriteString(render.EmptyLine(4) + dimStyle.Render("📁 Custom folder...") + "\n")
+		b.WriteString(render.EmptyLine(4) + dimStyle().Render("📁 Custom folder...") + "\n")
 	}
 
 	if len(m.volumes) == 0 {
 		b.WriteString("\n")
-		b.WriteString(render.EmptyLine(2) + dimStyle.Render("No removable devices detected.") + "\n")
+		b.WriteString(render.EmptyLine(2) + dimStyle().Render("No removable devices detected.") + "\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓ navigate  enter select  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("↑↓ navigate  enter select  esc back"))
 
 	return b.String()
 }
@@ -138,7 +142,7 @@ func (m Model) viewNewTarget() string {
 func (m Model) viewNewTargetFolder() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("Select Folder"))
+	b.WriteString(titleStyle().Render("Select Folder"))
 	b.WriteString("\n\n")
 
 	// Show device and current path
@@ -146,8 +150,8 @@ func (m Model) viewNewTargetFolder() string {
 	if label == "" {
 		label = m.newTarget.Name
 	}
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Device: "+label) + "\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Path: "+m.currentPath) + "\n\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Device: "+label) + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Path: "+m.currentPath) + "\n\n")
 
 	// Directory listing
 	hasParent := m.currentPath != "/"
@@ -156,9 +160,9 @@ func (m Model) viewNewTargetFolder() string {
 	// Show ".." if not at root
 	if hasParent {
 		if m.dirIdx == idx {
-			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ ..") + "\n")
+			b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> ..") + "\n")
 		} else {
-			b.WriteString(render.EmptyLine(4) + dimStyle.Render("..") + "\n")
+			b.WriteString(render.EmptyLine(4) + dimStyle().Render("..") + "\n")
 		}
 		idx++
 	}
@@ -166,20 +170,20 @@ func (m Model) viewNewTargetFolder() string {
 	// Show directories
 	for _, dir := range m.directories {
 		if m.dirIdx == idx {
-			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ "+dir) + "\n")
+			b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> "+dir) + "\n")
 		} else {
-			b.WriteString(render.EmptyLine(4) + dimStyle.Render(dir) + "\n")
+			b.WriteString(render.EmptyLine(4) + dimStyle().Render(dir) + "\n")
 		}
 		idx++
 	}
 
 	// Empty directory message
 	if len(m.directories) == 0 && !hasParent {
-		b.WriteString(render.EmptyLine(2) + dimStyle.Render("(empty)") + "\n")
+		b.WriteString(render.EmptyLine(2) + dimStyle().Render("(empty)") + "\n")
 	}
 
 	b.WriteString("\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓ navigate  enter open  space select  backspace up  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("↑↓ navigate  enter open  space select  backspace up  esc back"))
 
 	return b.String()
 }
@@ -187,13 +191,13 @@ func (m Model) viewNewTargetFolder() string {
 func (m Model) viewNewTargetConfig() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("Configure Target"))
+	b.WriteString(titleStyle().Render("Configure Target"))
 	b.WriteString("\n\n")
 
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Device: "+m.newTarget.DeviceLabel) + "\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder: "+m.newTarget.Subfolder) + "\n\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Device: "+m.newTarget.DeviceLabel) + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Folder: "+m.newTarget.Subfolder) + "\n\n")
 
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder structure:") + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Folder structure:") + "\n")
 	structures := []struct {
 		fs    export.FolderStructure
 		label string
@@ -206,14 +210,14 @@ func (m Model) viewNewTargetConfig() string {
 	for i, s := range structures {
 		line := fmt.Sprintf("[%d] %s", i+1, s.label)
 		if i == m.structureIdx {
-			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ "+line) + "\n")
+			b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> "+line) + "\n")
 		} else {
-			b.WriteString(render.EmptyLine(4) + dimStyle.Render(line) + "\n")
+			b.WriteString(render.EmptyLine(4) + dimStyle().Render(line) + "\n")
 		}
 	}
 
 	b.WriteString("\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓/1-3 select  enter save  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("↑↓/1-3 select  enter save  esc back"))
 
 	return b.String()
 }
@@ -221,15 +225,15 @@ func (m Model) viewNewTargetConfig() string {
 func (m Model) viewRenameTarget() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("Rename Target"))
+	b.WriteString(titleStyle().Render("Rename Target"))
 	b.WriteString("\n\n")
 
 	// Show current name with cursor
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("New name:") + "\n")
-	b.WriteString(render.EmptyLine(2) + selectedStyle.Render(m.renameInput+"▏") + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("New name:") + "\n")
+	b.WriteString(render.EmptyLine(2) + selectedStyle().Render(m.renameInput+"▏") + "\n")
 
 	b.WriteString("\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("enter confirm  esc cancel"))
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("enter confirm  esc cancel"))
 
 	return b.String()
 }
@@ -237,14 +241,14 @@ func (m Model) viewRenameTarget() string {
 func (m Model) viewCustomFolder() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("Custom Folder"))
+	b.WriteString(titleStyle().Render("Custom Folder"))
 	b.WriteString("\n\n")
 
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Enter folder path:") + "\n")
-	b.WriteString(render.EmptyLine(2) + selectedStyle.Render(m.customFolderInput+"▏") + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Enter folder path:") + "\n")
+	b.WriteString(render.EmptyLine(2) + selectedStyle().Render(m.customFolderInput+"▏") + "\n")
 
 	b.WriteString("\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("enter confirm  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("enter confirm  esc back"))
 
 	return b.String()
 }
@@ -252,12 +256,12 @@ func (m Model) viewCustomFolder() string {
 func (m Model) viewCustomFolderConfig() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("Configure Target"))
+	b.WriteString(titleStyle().Render("Configure Target"))
 	b.WriteString("\n\n")
 
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder: "+m.newTarget.Subfolder) + "\n\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Folder: "+m.newTarget.Subfolder) + "\n\n")
 
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("Folder structure:") + "\n")
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("Folder structure:") + "\n")
 	structures := []struct {
 		fs    export.FolderStructure
 		label string
@@ -270,14 +274,14 @@ func (m Model) viewCustomFolderConfig() string {
 	for i, s := range structures {
 		line := fmt.Sprintf("[%d] %s", i+1, s.label)
 		if i == m.structureIdx {
-			b.WriteString(render.EmptyLine(2) + selectedStyle.Render("▸ "+line) + "\n")
+			b.WriteString(render.EmptyLine(2) + selectedStyle().Render("> "+line) + "\n")
 		} else {
-			b.WriteString(render.EmptyLine(4) + dimStyle.Render(line) + "\n")
+			b.WriteString(render.EmptyLine(4) + dimStyle().Render(line) + "\n")
 		}
 	}
 
 	b.WriteString("\n")
-	b.WriteString(render.EmptyLine(2) + dimStyle.Render("↑↓/1-3 select  enter save  esc back"))
+	b.WriteString(render.EmptyLine(2) + dimStyle().Render("↑↓/1-3 select  enter save  esc back"))
 
 	return b.String()
 }

--- a/internal/ui/headerbar/headerbar.go
+++ b/internal/ui/headerbar/headerbar.go
@@ -62,7 +62,7 @@ func Render(currentMode string, width int, showDownloads bool, librarySubMode Li
 	contentWidth := innerWidth - (horizontalPadding * 2)
 
 	// Build logo: ~ WAVES (with gradient)
-	logo := lipgloss.NewStyle().Foreground(t.Secondary).Render("~") +
+	logo := t.BaseStyle().Foreground(t.Secondary).Render("~") +
 		" " +
 		styles.ApplyBoldGradient(logoText, t.Secondary, t.Primary)
 
@@ -81,7 +81,7 @@ func Render(currentMode string, width int, showDownloads bool, librarySubMode Li
 	b.WriteString(" ")
 
 	if fillWidth >= minDiags {
-		fill := lipgloss.NewStyle().Foreground(t.Primary).Render(strings.Repeat(diag, fillWidth))
+		fill := t.BaseStyle().Foreground(t.Primary).Render(strings.Repeat(diag, fillWidth))
 		b.WriteString(fill)
 		b.WriteString(" ")
 	} else {
@@ -95,11 +95,14 @@ func Render(currentMode string, width int, showDownloads bool, librarySubMode Li
 	b.WriteString(tabsContent)
 
 	// Wrap in border
-	borderStyle := lipgloss.NewStyle().
+	borderStyle := t.BaseStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(t.Border).
 		Padding(0, horizontalPadding).
 		Width(innerWidth)
+	if t.HasExplicitBackground {
+		borderStyle = borderStyle.BorderBackground(t.BgBase)
+	}
 
 	return borderStyle.Render(b.String())
 }
@@ -120,8 +123,8 @@ func renderTabs(currentMode string, showDownloads bool, librarySubMode LibrarySu
 
 		var keyStyle, nameStyle lipgloss.Style
 		if isActive {
-			keyStyle = lipgloss.NewStyle().Foreground(t.Primary).Bold(true)
-			nameStyle = lipgloss.NewStyle().Foreground(t.Primary).Bold(true)
+			keyStyle = t.BaseStyle().Foreground(t.Primary).Bold(true)
+			nameStyle = t.BaseStyle().Foreground(t.Primary).Bold(true)
 		} else {
 			keyStyle = t.S().Muted
 			nameStyle = t.S().Base

--- a/internal/ui/headerbar/headerbar.go
+++ b/internal/ui/headerbar/headerbar.go
@@ -78,17 +78,17 @@ func Render(currentMode string, width int, showDownloads bool, librarySubMode Li
 	// Build the header content
 	var b strings.Builder
 	b.WriteString(logo)
-	b.WriteString(" ")
+	b.WriteString(t.Bg(" "))
 
 	if fillWidth >= minDiags {
 		fill := t.BaseStyle().Foreground(t.Primary).Render(strings.Repeat(diag, fillWidth))
 		b.WriteString(fill)
-		b.WriteString(" ")
+		b.WriteString(t.Bg(" "))
 	} else {
 		// Not enough room for diagonals, just use remaining space
 		remaining := contentWidth - logoWidth - 1 - tabsWidth
 		if remaining > 0 {
-			b.WriteString(strings.Repeat(" ", remaining))
+			b.WriteString(t.Bg(strings.Repeat(" ", remaining)))
 		}
 	}
 
@@ -130,7 +130,7 @@ func renderTabs(currentMode string, showDownloads bool, librarySubMode LibrarySu
 			nameStyle = t.S().Base
 		}
 
-		part := keyStyle.Render(tab.key) + " " + nameStyle.Render(tab.name)
+		part := keyStyle.Render(tab.key) + t.Bg(" ") + nameStyle.Render(tab.name)
 
 		// Add mode indicator for library tab when active (using dot separator)
 		if tab.mode == "library" && isActive {
@@ -153,7 +153,7 @@ func renderTabs(currentMode string, showDownloads bool, librarySubMode LibrarySu
 	content := strings.Join(parts, separator)
 
 	// Help indicator: " │ ? Help"
-	helpIndicator := separator + t.S().Muted.Render("?") + " " + t.S().Base.Render("Help")
+	helpIndicator := separator + t.S().Muted.Render("?") + t.Bg(" ") + t.S().Base.Render("Help")
 
 	return content + helpIndicator
 }

--- a/internal/ui/headerbar/headerbar.go
+++ b/internal/ui/headerbar/headerbar.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
@@ -63,7 +64,7 @@ func Render(currentMode string, width int, showDownloads bool, librarySubMode Li
 
 	// Build logo: ~ WAVES (with gradient)
 	logo := t.BaseStyle().Foreground(t.Secondary).Render("~") +
-		" " +
+		render.EmptyLine(1) +
 		styles.ApplyBoldGradient(logoText, t.Secondary, t.Primary)
 
 	// Build tabs section
@@ -78,17 +79,17 @@ func Render(currentMode string, width int, showDownloads bool, librarySubMode Li
 	// Build the header content
 	var b strings.Builder
 	b.WriteString(logo)
-	b.WriteString(t.Bg(" "))
+	b.WriteString(render.EmptyLine(1))
 
 	if fillWidth >= minDiags {
 		fill := t.BaseStyle().Foreground(t.Primary).Render(strings.Repeat(diag, fillWidth))
 		b.WriteString(fill)
-		b.WriteString(t.Bg(" "))
+		b.WriteString(render.EmptyLine(1))
 	} else {
 		// Not enough room for diagonals, just use remaining space
 		remaining := contentWidth - logoWidth - 1 - tabsWidth
 		if remaining > 0 {
-			b.WriteString(t.Bg(strings.Repeat(" ", remaining)))
+			b.WriteString(render.EmptyLine(remaining))
 		}
 	}
 
@@ -130,7 +131,7 @@ func renderTabs(currentMode string, showDownloads bool, librarySubMode LibrarySu
 			nameStyle = t.S().Base
 		}
 
-		part := keyStyle.Render(tab.key) + t.Bg(" ") + nameStyle.Render(tab.name)
+		part := keyStyle.Render(tab.key) + render.EmptyLine(1) + nameStyle.Render(tab.name)
 
 		// Add mode indicator for library tab when active (using dot separator)
 		if tab.mode == "library" && isActive {
@@ -153,7 +154,7 @@ func renderTabs(currentMode string, showDownloads bool, librarySubMode LibrarySu
 	content := strings.Join(parts, separator)
 
 	// Help indicator: " │ ? Help"
-	helpIndicator := separator + t.S().Muted.Render("?") + t.Bg(" ") + t.S().Base.Render("Help")
+	helpIndicator := separator + t.S().Muted.Render("?") + render.EmptyLine(1) + t.S().Base.Render("Help")
 
 	return content + helpIndicator
 }

--- a/internal/ui/helpbindings/helpbindings.go
+++ b/internal/ui/helpbindings/helpbindings.go
@@ -157,9 +157,9 @@ func (m Model) buildContent() string {
 	var sb strings.Builder
 
 	t := styles.T()
-	keyStyle := lipgloss.NewStyle().Foreground(t.Primary).Bold(true)
+	keyStyle := t.BaseStyle().Foreground(t.Primary).Bold(true)
 	descStyle := t.S().Base
-	headerStyle := lipgloss.NewStyle().Foreground(t.Secondary).Bold(true)
+	headerStyle := t.BaseStyle().Foreground(t.Secondary).Bold(true)
 	separatorStyle := t.S().Subtle
 
 	// Find max key width for alignment

--- a/internal/ui/helpbindings/helpbindings.go
+++ b/internal/ui/helpbindings/helpbindings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llehouerou/waves/internal/keymap"
 	"github.com/llehouerou/waves/internal/ui"
 	"github.com/llehouerou/waves/internal/ui/popup"
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
@@ -135,7 +136,7 @@ func (m *Model) render() string {
 	// Pad visible lines to max width for consistent popup sizing
 	for i, line := range visibleLines {
 		if w := lipgloss.Width(line); w < maxWidth {
-			visibleLines[i] = line + strings.Repeat(" ", maxWidth-w)
+			visibleLines[i] = line + render.EmptyLine(maxWidth-w)
 		}
 	}
 
@@ -160,7 +161,6 @@ func (m Model) buildContent() string {
 	keyStyle := t.BaseStyle().Foreground(t.Primary).Bold(true)
 	descStyle := t.S().Base
 	headerStyle := t.BaseStyle().Foreground(t.Secondary).Bold(true)
-	separatorStyle := t.S().Subtle
 
 	// Find max key width for alignment
 	maxKeyWidth := 0
@@ -184,16 +184,15 @@ func (m Model) buildContent() string {
 			}
 			sb.WriteString(headerStyle.Render(label))
 			sb.WriteString("\n")
-			sb.WriteString(separatorStyle.Render(strings.Repeat("─", maxKeyWidth+15)))
+			sb.WriteString(render.Separator(maxKeyWidth + 15))
 			sb.WriteString("\n")
 			currentContext = b.Context
 		}
 
 		// Render key binding
 		keyStr := formatKeys(b.Keys)
-		paddedKey := keyStr + strings.Repeat(" ", maxKeyWidth-len(keyStr))
-		sb.WriteString(keyStyle.Render(paddedKey))
-		sb.WriteString("  ")
+		sb.WriteString(keyStyle.Render(keyStr))
+		sb.WriteString(render.EmptyLine(maxKeyWidth - len(keyStr) + 2))
 		sb.WriteString(descStyle.Render(b.Description))
 		sb.WriteString("\n")
 	}

--- a/internal/ui/jobbar/jobbar.go
+++ b/internal/ui/jobbar/jobbar.go
@@ -144,12 +144,14 @@ func renderWithProgressBar(job Job, width int) string {
 
 	var result strings.Builder
 	result.WriteString(barFilledStyle().Render(spinner))
-	result.WriteString(" ")
+	result.WriteString(render.EmptyLine(1))
 	result.WriteString(labelStyle().Render(label))
-	result.WriteString("  [")
+	result.WriteString(render.EmptyLine(2))
+	result.WriteString(progressStyle().Render("["))
 	result.WriteString(filledBar)
 	result.WriteString(emptyBar)
-	result.WriteString("] ")
+	result.WriteString(progressStyle().Render("]"))
+	result.WriteString(render.EmptyLine(1))
 	result.WriteString(progressStyle().Render(countStr))
 
 	return result.String()
@@ -177,10 +179,10 @@ func renderWithSpinner(job Job, width int) string {
 
 	var result strings.Builder
 	result.WriteString(barFilledStyle().Render(spinner))
-	result.WriteString(" ")
+	result.WriteString(render.EmptyLine(1))
 	result.WriteString(labelStyle().Render(label))
 	if countInfo != "" {
-		result.WriteString("  ")
+		result.WriteString(render.EmptyLine(2))
 		result.WriteString(progressStyle().Render(countInfo))
 	}
 

--- a/internal/ui/jobbar/jobbar.go
+++ b/internal/ui/jobbar/jobbar.go
@@ -69,7 +69,7 @@ func progressStyle() lipgloss.Style {
 }
 
 func barFilledStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(styles.T().Primary)
+	return styles.T().BaseStyle().Foreground(styles.T().Primary)
 }
 
 func barEmptyStyle() lipgloss.Style {

--- a/internal/ui/lastfmauth/lastfmauth.go
+++ b/internal/ui/lastfmauth/lastfmauth.go
@@ -52,7 +52,7 @@ const (
 const keyEsc = "esc"
 
 func titleStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Bold(true).
 		Foreground(styles.T().Primary)
 }
@@ -62,7 +62,7 @@ func labelStyle() lipgloss.Style {
 }
 
 func valueStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Foreground(styles.T().Secondary)
 }
 
@@ -71,12 +71,12 @@ func hintStyle() lipgloss.Style {
 }
 
 func errorStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Foreground(styles.T().Error)
 }
 
 func successStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Foreground(styles.T().Success)
 }
 

--- a/internal/ui/librarybrowser/view.go
+++ b/internal/ui/librarybrowser/view.go
@@ -180,7 +180,7 @@ func (m Model) renderAlbumItems(width, height int) []string {
 
 		if yearWidth > 0 {
 			// Style year in a muted tone with right padding
-			yearStyled := t.S().Muted.Render(yearStr) + " "
+			yearStyled := t.S().Muted.Render(yearStr) + render.EmptyLine(1)
 			line := render.Row(leftStyled, yearStyled, width)
 			lines[i] = m.styleItemBg(line, isCursor, isActive)
 		} else {

--- a/internal/ui/librarybrowser/view.go
+++ b/internal/ui/librarybrowser/view.go
@@ -89,13 +89,13 @@ func (m Model) styleItem(line string, isCursor, isActive bool) string {
 	}
 }
 
-// styleItemText applies foreground color only (no background) for inline styling.
+// styleItemText applies foreground color (and cursor background when active) for inline styling.
 func (m Model) styleItemText(text string, isCursor, isActive bool) string {
 	t := styles.T()
 
 	switch {
 	case isCursor && isActive && m.focused:
-		return t.BaseStyle().Foreground(t.FgBase).Render(text)
+		return t.BaseStyle().Background(t.BgCursor).Foreground(t.FgBase).Render(text)
 	case isCursor:
 		return t.S().Base.Render(text)
 	case isActive:
@@ -180,7 +180,11 @@ func (m Model) renderAlbumItems(width, height int) []string {
 
 		if yearWidth > 0 {
 			// Style year in a muted tone with right padding
-			yearStyled := t.S().Muted.Render(yearStr) + render.EmptyLine(1)
+			yearStyle := t.S().Muted
+			if isCursor && isActive && m.focused {
+				yearStyle = yearStyle.Background(t.BgCursor)
+			}
+			yearStyled := yearStyle.Render(yearStr) + render.EmptyLine(1)
 			line := render.Row(leftStyled, yearStyled, width)
 			lines[i] = m.styleItemBg(line, isCursor, isActive)
 		} else {

--- a/internal/ui/librarybrowser/view.go
+++ b/internal/ui/librarybrowser/view.go
@@ -57,15 +57,18 @@ func (m Model) renderBorderedColumn(title string, lines []string, width int, act
 	}
 
 	// Render the title as the first content line (style after pad to avoid ANSI truncation)
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(borderColor)
+	titleStyle := t.BaseStyle().Bold(true).Foreground(borderColor)
 	titleLine := titleStyle.Render(render.TruncateAndPad(title, width))
 
 	content := titleLine + "\n" + render.EmptyLine(width) + "\n" + strings.Join(lines, "\n") + "\n" + render.EmptyLine(width)
 
-	style := lipgloss.NewStyle().
+	style := t.BaseStyle().
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
 		Width(width)
+	if t.HasExplicitBackground {
+		style = style.BorderBackground(t.BgBase)
+	}
 
 	return style.Render(content)
 }
@@ -92,7 +95,7 @@ func (m Model) styleItemText(text string, isCursor, isActive bool) string {
 
 	switch {
 	case isCursor && isActive && m.focused:
-		return lipgloss.NewStyle().Foreground(t.FgBase).Render(text)
+		return t.BaseStyle().Foreground(t.FgBase).Render(text)
 	case isCursor:
 		return t.S().Base.Render(text)
 	case isActive:
@@ -105,7 +108,7 @@ func (m Model) styleItemText(text string, isCursor, isActive bool) string {
 // styleItemBg applies only the background style to a pre-styled line.
 func (m Model) styleItemBg(line string, isCursor, isActive bool) string {
 	if isCursor && isActive && m.focused {
-		return lipgloss.NewStyle().Background(styles.T().BgCursor).Render(line)
+		return styles.T().BaseStyle().Background(styles.T().BgCursor).Render(line)
 	}
 	return line
 }

--- a/internal/ui/lyrics/lyrics.go
+++ b/internal/ui/lyrics/lyrics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/llehouerou/waves/internal/ui"
 	"github.com/llehouerou/waves/internal/ui/action"
 	"github.com/llehouerou/waves/internal/ui/popup"
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
@@ -256,7 +257,7 @@ func (m *Model) renderLoading() string {
 			case trackInfoLine:
 				lines[i] = m.centerToWidth(subtle.Render(trackInfo), m.prevMaxWidth)
 			default:
-				lines[i] = strings.Repeat(" ", m.prevMaxWidth)
+				lines[i] = render.EmptyLine(m.prevMaxWidth)
 			}
 		}
 		return strings.Join(lines, "\n")
@@ -337,7 +338,7 @@ func (m *Model) renderLyrics() string {
 	// Pad lines to max width for consistent popup sizing
 	for i, line := range visibleLines {
 		if w := lipgloss.Width(line); w < maxWidth {
-			visibleLines[i] = line + strings.Repeat(" ", maxWidth-w)
+			visibleLines[i] = line + render.EmptyLine(maxWidth-w)
 		}
 	}
 
@@ -453,7 +454,7 @@ func (m *Model) centerToWidth(s string, width int) string {
 		return s
 	}
 	pad := (width - w) / 2
-	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-w-pad)
+	return render.EmptyLine(pad) + s + render.EmptyLine(width-w-pad)
 }
 
 // ActionMsg creates an action.Msg for a lyrics action.

--- a/internal/ui/lyrics/lyrics.go
+++ b/internal/ui/lyrics/lyrics.go
@@ -207,7 +207,6 @@ func (m *Model) View() string {
 func (m *Model) render() string {
 	t := styles.T()
 	titleStyle := t.S().Title
-	footerStyle := t.S().Subtle
 
 	var content string
 	switch m.state {
@@ -223,10 +222,10 @@ func (m *Model) render() string {
 
 	var result strings.Builder
 	result.WriteString(titleStyle.Render("Lyrics"))
-	result.WriteString("\n\n")
+	result.WriteString("\n" + render.EmptyLine(1) + "\n")
 	result.WriteString(content)
-	result.WriteString("\n\n")
-	result.WriteString(footerStyle.Render(m.buildFooter()))
+	result.WriteString("\n" + render.EmptyLine(1) + "\n")
+	result.WriteString(m.buildFooter())
 
 	return result.String()
 }
@@ -283,7 +282,7 @@ func (m *Model) renderNotFound() string {
 
 	var sb strings.Builder
 	sb.WriteString(subtle.Render(notFoundMsg))
-	sb.WriteString("\n\n")
+	sb.WriteString("\n" + render.EmptyLine(1) + "\n")
 	sb.WriteString(subtle.Render(trackInfo))
 	return sb.String()
 }
@@ -295,7 +294,7 @@ func (m *Model) renderError() string {
 
 	var sb strings.Builder
 	sb.WriteString(errorStyle.Render("Error loading lyrics"))
-	sb.WriteString("\n\n")
+	sb.WriteString("\n" + render.EmptyLine(1) + "\n")
 	sb.WriteString(subtle.Render(m.errorMsg))
 	return sb.String()
 }
@@ -346,18 +345,22 @@ func (m *Model) renderLyrics() string {
 }
 
 func (m *Model) buildFooter() string {
+	t := styles.T()
+	footerStyle := t.S().Subtle
+	sep := footerStyle.Render(" · ")
+
 	var parts []string
 
 	// Loading indicator when fetching new lyrics
 	if m.state == StateLoading {
-		parts = append(parts, "loading...")
+		parts = append(parts, footerStyle.Render("loading..."))
 	}
 
 	// Position/duration
 	if m.duration > 0 {
-		parts = append(parts, fmt.Sprintf("%s / %s",
+		parts = append(parts, footerStyle.Render(fmt.Sprintf("%s / %s",
 			formatDuration(m.position),
-			formatDuration(m.duration)))
+			formatDuration(m.duration))))
 	}
 
 	// Sync indicator (only when loaded, not during loading)
@@ -367,12 +370,12 @@ func (m *Model) buildFooter() string {
 
 	// Scroll info
 	if m.state == StateLoaded && m.maxScroll() > 0 {
-		parts = append(parts, "j/k scroll")
+		parts = append(parts, footerStyle.Render("j/k scroll"))
 	}
 
-	parts = append(parts, "esc close")
+	parts = append(parts, footerStyle.Render("esc close"))
 
-	return strings.Join(parts, " · ")
+	return strings.Join(parts, sep)
 }
 
 func (m *Model) visibleHeight() int {

--- a/internal/ui/lyrics/lyrics.go
+++ b/internal/ui/lyrics/lyrics.go
@@ -290,7 +290,7 @@ func (m *Model) renderNotFound() string {
 func (m *Model) renderError() string {
 	t := styles.T()
 	subtle := t.S().Subtle
-	errorStyle := lipgloss.NewStyle().Foreground(t.Error)
+	errorStyle := t.BaseStyle().Foreground(t.Error)
 
 	var sb strings.Builder
 	sb.WriteString(errorStyle.Render("Error loading lyrics"))
@@ -305,7 +305,7 @@ func (m *Model) renderLyrics() string {
 	}
 
 	t := styles.T()
-	currentStyle := lipgloss.NewStyle().Foreground(t.Primary).Bold(true)
+	currentStyle := t.BaseStyle().Foreground(t.Primary).Bold(true)
 	normalStyle := t.S().Subtle
 
 	lines := make([]string, len(m.lyrics.Lines))
@@ -421,9 +421,9 @@ func formatDuration(d time.Duration) string {
 func (m *Model) renderSyncIndicator() string {
 	t := styles.T()
 	if !m.lyrics.IsSynced() {
-		return lipgloss.NewStyle().Foreground(t.Error).Render("unsynced")
+		return t.BaseStyle().Foreground(t.Error).Render("unsynced")
 	}
-	syncStyle := lipgloss.NewStyle().Foreground(t.Primary)
+	syncStyle := t.BaseStyle().Foreground(t.Primary)
 	if m.autoScroll {
 		return syncStyle.Render("synced")
 	}

--- a/internal/ui/playerbar/expanded.go
+++ b/internal/ui/playerbar/expanded.go
@@ -116,7 +116,9 @@ func RenderExpanded(s State, width int) string {
 	radioLine := ""
 	if s.RadioEnabled {
 		radioLabel := radioStyle().Render(icons.Radio() + " Radio on")
-		radioLine = lipgloss.PlaceHorizontal(textWidth, lipgloss.Right, radioLabel)
+		radioLabelWidth := lipgloss.Width(radioLabel)
+		padding := max(textWidth-radioLabelWidth, 0)
+		radioLine = render.EmptyLine(padding) + radioLabel
 	}
 
 	lines = append(lines,

--- a/internal/ui/playerbar/expanded.go
+++ b/internal/ui/playerbar/expanded.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llehouerou/waves/internal/icons"
 	"github.com/llehouerou/waves/internal/ui"
 	"github.com/llehouerou/waves/internal/ui/render"
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 // AlbumArtWidth is the width of album art in the expanded view (in terminal cells).
@@ -131,14 +132,14 @@ func RenderExpanded(s State, width int) string {
 	volumeStr := RenderVolumeCompact(s.Volume, s.Muted)
 	volumeWidth := lipgloss.Width(volumeStr)
 	progressBar := renderStyledProgressBar(s.Position, s.Duration, textWidth-volumeWidth-2, s.Playing)
-	lines = append(lines, progressBar+"  "+volumeStr)
+	lines = append(lines, progressBar+render.EmptyLine(2)+volumeStr)
 
 	textContent := strings.Join(lines, "\n")
 
 	// Combine album art and text content
 	var content string
 	if s.HasAlbumArt && s.AlbumArtPlaceholder != "" {
-		content = lipgloss.JoinHorizontal(lipgloss.Top, s.AlbumArtPlaceholder, "  ", textContent)
+		content = lipgloss.JoinHorizontal(lipgloss.Top, s.AlbumArtPlaceholder, render.EmptyLine(2), textContent)
 	} else {
 		content = textContent
 	}
@@ -195,6 +196,7 @@ func renderStyledProgressBar(position, duration time.Duration, width int, playin
 
 	posStr := formatDuration(position)
 	durStr := formatDuration(duration)
+	sp2 := render.EmptyLine(2)
 
 	// Calculate space for the bar itself
 	// Format: "▶  1:23  ━━━━━───  4:56"
@@ -203,7 +205,7 @@ func renderStyledProgressBar(position, duration time.Duration, width int, playin
 
 	if barWidth < 5 {
 		// Too narrow for bar, just show times
-		return status + "  " + progressTimeStyle().Render(posStr+" / "+durStr)
+		return styles.T().Bg(status) + sp2 + progressTimeStyle().Render(posStr+" / "+durStr)
 	}
 
 	// Calculate filled portion
@@ -217,5 +219,5 @@ func renderStyledProgressBar(position, duration time.Duration, width int, playin
 	filledBar := progressBarFilled().Render(strings.Repeat("━", filled))
 	emptyBar := progressBarEmpty().Render(strings.Repeat("─", barWidth-filled))
 
-	return status + "  " + progressTimeStyle().Render(posStr) + "  " + filledBar + emptyBar + "  " + progressTimeStyle().Render(durStr)
+	return styles.T().Bg(status) + sp2 + progressTimeStyle().Render(posStr) + sp2 + filledBar + emptyBar + sp2 + progressTimeStyle().Render(durStr)
 }

--- a/internal/ui/playerbar/playerbar.go
+++ b/internal/ui/playerbar/playerbar.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llehouerou/waves/internal/icons"
 	"github.com/llehouerou/waves/internal/player"
 	"github.com/llehouerou/waves/internal/ui/render"
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 // DisplayMode controls the player bar appearance.
@@ -115,10 +116,12 @@ func renderCompact(s State, width int) string {
 		status = pauseSymbol()
 	}
 
+	sp := render.EmptyLine(1)
+
 	// Add radio indicator if enabled
 	radioIndicator := ""
 	if s.RadioEnabled {
-		radioIndicator = radioStyle().Render(icons.Radio()) + " "
+		radioIndicator = radioStyle().Render(icons.Radio()) + sp
 	}
 
 	// Build title
@@ -162,11 +165,11 @@ func renderCompact(s State, width int) string {
 	volumeWidth := lipgloss.Width(volumeStr)
 
 	// Calculate fixed widths
-	separator := "   "
-	sepWidth := lipgloss.Width(separator)
+	separator := render.EmptyLine(3)
+	sepWidth := 3
 	timeWidth := lipgloss.Width(timeStr)
 	radioWidth := lipgloss.Width(radioIndicator)
-	statusWidth := lipgloss.Width(status+"  ") + radioWidth // status + radio indicator + space before bar
+	statusWidth := lipgloss.Width(status) + 2 + radioWidth // status + radio indicator + space before bar
 	trackNumWidth := lipgloss.Width(trackNum)
 
 	// Calculate how much space we need for track info
@@ -231,8 +234,8 @@ func renderCompact(s State, width int) string {
 	}
 	content.WriteString(separator)
 	content.WriteString(radioIndicator)
-	content.WriteString(status)
-	content.WriteString("  ")
+	content.WriteString(styles.T().Bg(status))
+	content.WriteString(render.EmptyLine(2))
 	content.WriteString(filledBar)
 	content.WriteString(emptyBar)
 	content.WriteString(separator)

--- a/internal/ui/playerbar/styles.go
+++ b/internal/ui/playerbar/styles.go
@@ -18,16 +18,26 @@ func pauseSymbol() string {
 }
 
 func barStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	t := styles.T()
+	s := t.BaseStyle().
 		BorderStyle(lipgloss.RoundedBorder()).
-		BorderForeground(styles.T().Border)
+		BorderForeground(t.Border)
+	if t.HasExplicitBackground {
+		s = s.BorderBackground(t.BgBase)
+	}
+	return s
 }
 
 func expandedBarStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	t := styles.T()
+	s := t.BaseStyle().
 		BorderStyle(lipgloss.RoundedBorder()).
-		BorderForeground(styles.T().Border).
+		BorderForeground(t.Border).
 		Padding(0, 2)
+	if t.HasExplicitBackground {
+		s = s.BorderBackground(t.BgBase)
+	}
+	return s
 }
 
 func titleStyle() lipgloss.Style {
@@ -47,13 +57,13 @@ func progressTimeStyle() lipgloss.Style {
 }
 
 func progressBarFilled() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(styles.T().Primary)
+	return styles.T().BaseStyle().Foreground(styles.T().Primary)
 }
 
 func progressBarEmpty() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(styles.T().FgSubtle)
+	return styles.T().BaseStyle().Foreground(styles.T().FgSubtle)
 }
 
 func radioStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(styles.T().Secondary)
+	return styles.T().BaseStyle().Foreground(styles.T().Secondary)
 }

--- a/internal/ui/popup/popup.go
+++ b/internal/ui/popup/popup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
@@ -134,7 +135,7 @@ func centerLine(s string, width int) string {
 		return s
 	}
 	pad := (width - w) / 2
-	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-w-pad)
+	return render.EmptyLine(pad) + s + render.EmptyLine(width-w-pad)
 }
 
 func padLine(s string, width int) string {
@@ -142,7 +143,7 @@ func padLine(s string, width int) string {
 	if w >= width {
 		return s
 	}
-	return s + strings.Repeat(" ", width-w)
+	return s + render.EmptyLine(width-w)
 }
 
 // Center centers pre-rendered content in the terminal.
@@ -173,10 +174,10 @@ func centerBox(box string, termWidth, termHeight int) string {
 
 	var result strings.Builder
 	for range padTop {
-		result.WriteString(strings.Repeat(" ", termWidth) + "\n")
+		result.WriteString(render.EmptyLine(termWidth) + "\n")
 	}
 	for _, line := range lines {
-		result.WriteString(strings.Repeat(" ", padLeft))
+		result.WriteString(render.EmptyLine(padLeft))
 		result.WriteString(line)
 		result.WriteString("\n")
 	}
@@ -283,7 +284,7 @@ func Compose(base, popupView string, width, _ int) string {
 
 		// Pad base line if needed
 		if baseWidth < width {
-			baseLine += strings.Repeat(" ", width-baseWidth)
+			baseLine += render.EmptyLine(width - baseWidth)
 		}
 
 		// Construct result: base[0:startCol] + overlay + base[endCol:]
@@ -293,7 +294,7 @@ func Compose(base, popupView string, width, _ int) string {
 		prefixWidth := ansi.StringWidth(ansi.Strip(prefix))
 		if prefixWidth < startCol {
 			// Wide char was excluded from prefix - pad with spaces
-			prefix += strings.Repeat(" ", startCol-prefixWidth)
+			prefix += render.EmptyLine(startCol - prefixWidth)
 		}
 
 		result := prefix + overlayContent
@@ -309,7 +310,7 @@ func Compose(base, popupView string, width, _ int) string {
 				suffix = " " + ansi.Cut(suffix, suffixWidth-expectedSuffixWidth+1, suffixWidth)
 			} else if suffixWidth < expectedSuffixWidth {
 				// Pad if suffix is too short
-				result += strings.Repeat(" ", expectedSuffixWidth-suffixWidth)
+				result += render.EmptyLine(expectedSuffixWidth - suffixWidth)
 			}
 			result += suffix
 		}

--- a/internal/ui/popup/popup.go
+++ b/internal/ui/popup/popup.go
@@ -101,11 +101,15 @@ func (p *Dialog) Render(termWidth, termHeight int) string {
 
 	// Apply border and padding
 	content := strings.Join(lines, "\n")
-	boxStyle := lipgloss.NewStyle().
+	t := styles.T()
+	boxStyle := t.BaseStyle().
 		Border(style.Border).
 		BorderForeground(style.BorderColor).
 		Padding(0, 1).
 		Width(innerWidth)
+	if t.HasExplicitBackground {
+		boxStyle = boxStyle.BorderBackground(t.BgBase)
+	}
 
 	box := boxStyle.Render(content)
 
@@ -197,12 +201,16 @@ var (
 func RenderBordered(content string, screenW, screenH int, size SizeConfig) string {
 	width, height := calculateDimensions(content, screenW, screenH, size)
 
-	boxStyle := lipgloss.NewStyle().
+	pt := styles.T()
+	boxStyle := pt.BaseStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(styles.T().Border).
+		BorderForeground(pt.Border).
 		Width(width-2). // Account for border
 		Height(height-2).
 		Padding(1, 2)
+	if pt.HasExplicitBackground {
+		boxStyle = boxStyle.BorderBackground(pt.BgBase)
+	}
 
 	box := boxStyle.Render(content)
 	return Center(box, screenW, screenH)

--- a/internal/ui/queuepanel/styles.go
+++ b/internal/ui/queuepanel/styles.go
@@ -32,17 +32,17 @@ func dimmedStyle() lipgloss.Style {
 }
 
 func multiSelectHeaderStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Bold(true).
 		Foreground(styles.T().Primary)
 }
 
 func modeIconStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Foreground(styles.T().Primary).
 		Bold(true)
 }
 
 func radioIconStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(styles.T().Secondary)
+	return styles.T().BaseStyle().Foreground(styles.T().Secondary)
 }

--- a/internal/ui/queuepanel/view.go
+++ b/internal/ui/queuepanel/view.go
@@ -101,7 +101,7 @@ func (m Model) renderModeIcons() (styled string, width int) {
 	raw := strings.Join(rawParts, "  ")
 	// Calculate actual width: icon widths + spaces between + trailing space
 	width = runewidth.StringWidth(raw) + 1
-	styled = strings.Join(styledParts, "  ") + " "
+	styled = strings.Join(styledParts, render.EmptyLine(2)) + render.EmptyLine(1)
 	return styled, width
 }
 

--- a/internal/ui/render/text.go
+++ b/internal/ui/render/text.go
@@ -30,8 +30,15 @@ func TruncateEllipsis(s string, maxWidth int) string {
 
 // Pad fills a string with spaces to reach the specified width.
 // Uses runewidth for proper handling of wide characters.
+// Applies the theme background to padding spaces when an explicit background is set.
 func Pad(s string, width int) string {
-	return runewidth.FillRight(s, width)
+	padded := runewidth.FillRight(s, width)
+	currentWidth := lipgloss.Width(s)
+	if currentWidth < width {
+		// The padding portion needs the theme background
+		return s + EmptyLine(width-currentWidth)
+	}
+	return padded
 }
 
 // TruncateAndPad truncates a string if necessary, then pads to the exact width.
@@ -47,11 +54,12 @@ func TruncateAndPadEllipsis(s string, width int) string {
 
 // Row creates a row with left and right aligned content separated by spaces.
 // The total width of the output will be exactly width characters.
+// Applies the theme background to gap spaces when an explicit background is set.
 func Row(left, right string, width int) string {
 	leftWidth := lipgloss.Width(left)
 	rightWidth := lipgloss.Width(right)
 	gap := max(width-leftWidth-rightWidth, 1)
-	return left + strings.Repeat(" ", gap) + right
+	return left + EmptyLine(gap) + right
 }
 
 // Separator creates a horizontal separator line of the specified width.

--- a/internal/ui/render/text.go
+++ b/internal/ui/render/text.go
@@ -30,15 +30,8 @@ func TruncateEllipsis(s string, maxWidth int) string {
 
 // Pad fills a string with spaces to reach the specified width.
 // Uses runewidth for proper handling of wide characters.
-// Applies the theme background to padding spaces when an explicit background is set.
 func Pad(s string, width int) string {
-	padded := runewidth.FillRight(s, width)
-	currentWidth := lipgloss.Width(s)
-	if currentWidth < width {
-		// The padding portion needs the theme background
-		return s + EmptyLine(width-currentWidth)
-	}
-	return padded
+	return runewidth.FillRight(s, width)
 }
 
 // TruncateAndPad truncates a string if necessary, then pads to the exact width.

--- a/internal/ui/render/text.go
+++ b/internal/ui/render/text.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
+
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 // Truncate shortens a string to fit within maxWidth, adding an ellipsis if truncated.
@@ -53,11 +55,13 @@ func Row(left, right string, width int) string {
 }
 
 // Separator creates a horizontal separator line of the specified width.
+// Applies the theme background when an explicit background is set.
 func Separator(width int) string {
-	return strings.Repeat("─", width)
+	return styles.T().Bg(strings.Repeat("─", width))
 }
 
 // EmptyLine creates an empty line (spaces) of the specified width.
+// Applies the theme background when an explicit background is set.
 func EmptyLine(width int) string {
-	return strings.Repeat(" ", width)
+	return styles.T().Bg(strings.Repeat(" ", width))
 }

--- a/internal/ui/scanreport/scanreport.go
+++ b/internal/ui/scanreport/scanreport.go
@@ -103,7 +103,7 @@ func (m Model) buildContent() string {
 		t := styles.T()
 		if !hasChanges {
 			dimStyle := t.S().Subtle
-			sb.WriteString("  ")
+			sb.WriteString(render.EmptyLine(2))
 			sb.WriteString(dimStyle.Render("No changes"))
 			sb.WriteString("\n")
 			continue
@@ -139,7 +139,7 @@ func (m Model) buildContent() string {
 
 func (m Model) renderCategory(sb *strings.Builder, label string, paths []string, color lipgloss.Color) {
 	labelStyle := styles.T().BaseStyle().Foreground(color)
-	sb.WriteString("  ")
+	sb.WriteString(render.EmptyLine(2))
 	sb.WriteString(labelStyle.Render(fmt.Sprintf("%s: %d", label, len(paths))))
 	sb.WriteString("\n")
 
@@ -148,12 +148,13 @@ func (m Model) renderCategory(sb *strings.Builder, label string, paths []string,
 	for i, path := range paths {
 		if i >= m.MaxExamples {
 			remaining := len(paths) - m.MaxExamples
-			sb.WriteString("    ")
+			sb.WriteString(render.EmptyLine(4))
 			sb.WriteString(dimStyle.Render(fmt.Sprintf("... and %d more", remaining)))
 			sb.WriteString("\n")
 			break
 		}
-		sb.WriteString("    • ")
+		sb.WriteString(render.EmptyLine(4))
+		sb.WriteString(styles.T().S().Muted.Render("• "))
 		sb.WriteString(dimStyle.Render(path))
 		sb.WriteString("\n")
 	}

--- a/internal/ui/scanreport/scanreport.go
+++ b/internal/ui/scanreport/scanreport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/llehouerou/waves/internal/library"
 	"github.com/llehouerou/waves/internal/ui"
 	"github.com/llehouerou/waves/internal/ui/popup"
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
@@ -93,7 +94,7 @@ func (m Model) buildContent() string {
 		}
 
 		stats := m.Stats.BySource[src]
-		sourceStyle := lipgloss.NewStyle().Bold(true)
+		sourceStyle := styles.T().BaseStyle().Bold(true)
 		sb.WriteString(sourceStyle.Render(src))
 		sb.WriteString("\n")
 
@@ -126,10 +127,10 @@ func (m Model) buildContent() string {
 
 	// Total line
 	sb.WriteString("\n")
-	sb.WriteString(strings.Repeat("─", 40))
+	sb.WriteString(render.Separator(40))
 	sb.WriteString("\n")
 
-	totalStyle := lipgloss.NewStyle().Bold(true)
+	totalStyle := styles.T().BaseStyle().Bold(true)
 	sb.WriteString(totalStyle.Render(fmt.Sprintf("Total: %d added, %d removed, %d updated",
 		totalAdded, totalRemoved, totalUpdated)))
 

--- a/internal/ui/scanreport/scanreport.go
+++ b/internal/ui/scanreport/scanreport.go
@@ -137,7 +137,7 @@ func (m Model) buildContent() string {
 }
 
 func (m Model) renderCategory(sb *strings.Builder, label string, paths []string, color lipgloss.Color) {
-	labelStyle := lipgloss.NewStyle().Foreground(color)
+	labelStyle := styles.T().BaseStyle().Foreground(color)
 	sb.WriteString("  ")
 	sb.WriteString(labelStyle.Render(fmt.Sprintf("%s: %d", label, len(paths))))
 	sb.WriteString("\n")

--- a/internal/ui/similarartists/view.go
+++ b/internal/ui/similarartists/view.go
@@ -4,39 +4,35 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
-
+	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 var (
-	titleStyle = lipgloss.NewStyle().
+	titleStyle = styles.T().BaseStyle().
 			Bold(true).
 			Foreground(styles.T().Primary).
 			MarginBottom(1)
 
-	sectionStyle = lipgloss.NewStyle().
+	sectionStyle = styles.T().BaseStyle().
 			Foreground(styles.T().FgMuted).
 			Bold(true)
 
-	separatorStyle = lipgloss.NewStyle().
-			Foreground(styles.T().FgSubtle)
-
-	selectedStyle = lipgloss.NewStyle().
+	selectedStyle = styles.T().BaseStyle().
 			Foreground(styles.T().Primary).
 			Bold(true)
 
-	normalStyle = lipgloss.NewStyle().
+	normalStyle = styles.T().BaseStyle().
 			Foreground(styles.T().FgBase)
 
-	scoreStyle = lipgloss.NewStyle().
+	scoreStyle = styles.T().BaseStyle().
 			Foreground(styles.T().FgMuted)
 
-	helpStyle = lipgloss.NewStyle().
+	helpStyle = styles.T().BaseStyle().
 			Foreground(styles.T().FgMuted).
 			MarginTop(1)
 
-	errorStyle = lipgloss.NewStyle().
+	errorStyle = styles.T().BaseStyle().
 			Foreground(styles.T().Error)
 )
 
@@ -76,7 +72,7 @@ func (m *Model) View() string {
 		b.WriteString("\n")
 		b.WriteString(sectionStyle.Render("In Library"))
 		b.WriteString("\n")
-		b.WriteString(separatorStyle.Render(strings.Repeat("─", 40)))
+		b.WriteString(render.Separator(40))
 		b.WriteString("\n")
 		for i, item := range m.inLibrary {
 			b.WriteString(m.renderItem(item, i))
@@ -89,7 +85,7 @@ func (m *Model) View() string {
 		b.WriteString("\n")
 		b.WriteString(sectionStyle.Render("Not in Library"))
 		b.WriteString("\n")
-		b.WriteString(separatorStyle.Render(strings.Repeat("─", 40)))
+		b.WriteString(render.Separator(40))
 		b.WriteString("\n")
 		for i, item := range m.notInLibrary {
 			idx := len(m.inLibrary) + i

--- a/internal/ui/similarartists/view.go
+++ b/internal/ui/similarartists/view.go
@@ -4,44 +4,58 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/llehouerou/waves/internal/ui/render"
 	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
-var (
-	titleStyle = styles.T().BaseStyle().
-			Bold(true).
-			Foreground(styles.T().Primary).
-			MarginBottom(1)
+func titleStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Bold(true).
+		Foreground(styles.T().Primary).
+		MarginBottom(1)
+}
 
-	sectionStyle = styles.T().BaseStyle().
-			Foreground(styles.T().FgMuted).
-			Bold(true)
+func sectionStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Foreground(styles.T().FgMuted).
+		Bold(true)
+}
 
-	selectedStyle = styles.T().BaseStyle().
-			Foreground(styles.T().Primary).
-			Bold(true)
+func selectedStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Foreground(styles.T().Primary).
+		Bold(true)
+}
 
-	normalStyle = styles.T().BaseStyle().
-			Foreground(styles.T().FgBase)
+func normalStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Foreground(styles.T().FgBase)
+}
 
-	scoreStyle = styles.T().BaseStyle().
-			Foreground(styles.T().FgMuted)
+func scoreStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Foreground(styles.T().FgMuted)
+}
 
-	helpStyle = styles.T().BaseStyle().
-			Foreground(styles.T().FgMuted).
-			MarginTop(1)
+func helpStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Foreground(styles.T().FgMuted).
+		MarginTop(1)
+}
 
-	errorStyle = styles.T().BaseStyle().
-			Foreground(styles.T().Error)
-)
+func errorStyle() lipgloss.Style {
+	return styles.T().BaseStyle().
+		Foreground(styles.T().Error)
+}
 
 // View renders the popup content.
 func (m *Model) View() string {
 	var b strings.Builder
 
 	// Title
-	b.WriteString(titleStyle.Render("Similar to: " + m.artistName))
+	b.WriteString(titleStyle().Render("Similar to: " + m.artistName))
 	b.WriteString("\n")
 
 	// Loading state
@@ -53,9 +67,9 @@ func (m *Model) View() string {
 	// Error state
 	if m.errorMsg != "" {
 		b.WriteString("\n")
-		b.WriteString(errorStyle.Render(m.errorMsg))
+		b.WriteString(errorStyle().Render(m.errorMsg))
 		b.WriteString("\n\n")
-		b.WriteString(helpStyle.Render("esc: close"))
+		b.WriteString(helpStyle().Render("esc: close"))
 		return b.String()
 	}
 
@@ -63,14 +77,14 @@ func (m *Model) View() string {
 	if m.totalItems() == 0 {
 		b.WriteString("\nNo similar artists found.")
 		b.WriteString("\n\n")
-		b.WriteString(helpStyle.Render("esc: close"))
+		b.WriteString(helpStyle().Render("esc: close"))
 		return b.String()
 	}
 
 	// In Library section
 	if len(m.inLibrary) > 0 {
 		b.WriteString("\n")
-		b.WriteString(sectionStyle.Render("In Library"))
+		b.WriteString(sectionStyle().Render("In Library"))
 		b.WriteString("\n")
 		b.WriteString(render.Separator(40))
 		b.WriteString("\n")
@@ -83,7 +97,7 @@ func (m *Model) View() string {
 	// Not in Library section
 	if len(m.notInLibrary) > 0 {
 		b.WriteString("\n")
-		b.WriteString(sectionStyle.Render("Not in Library"))
+		b.WriteString(sectionStyle().Render("Not in Library"))
 		b.WriteString("\n")
 		b.WriteString(render.Separator(40))
 		b.WriteString("\n")
@@ -96,7 +110,7 @@ func (m *Model) View() string {
 
 	// Help
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("enter: go/download  d: download  esc: close"))
+	b.WriteString(helpStyle().Render("enter: go/download  d: download  esc: close"))
 
 	return b.String()
 }
@@ -109,6 +123,6 @@ func (m *Model) renderItem(item SimilarArtistItem, index int) string {
 		style = selectedStyle
 	}
 
-	score := scoreStyle.Render(fmt.Sprintf("(%d%%)", int(item.MatchScore*100)))
-	return fmt.Sprintf("%s%s %s", cursor, style.Render(item.Name), score)
+	score := scoreStyle().Render(fmt.Sprintf("(%d%%)", int(item.MatchScore*100)))
+	return fmt.Sprintf("%s%s %s", cursor, style().Render(item.Name), score)
 }

--- a/internal/ui/styles/gradient.go
+++ b/internal/ui/styles/gradient.go
@@ -35,8 +35,10 @@ func applyGradient(text string, bold bool, from, to lipgloss.Color) string {
 		return ""
 	}
 
+	base := T().baseStyle()
+
 	if len(clusters) == 1 {
-		style := lipgloss.NewStyle().Foreground(from)
+		style := base.Foreground(from)
 		if bold {
 			style = style.Bold(true)
 		}
@@ -48,7 +50,7 @@ func applyGradient(text string, bold bool, from, to lipgloss.Color) string {
 
 	var b strings.Builder
 	for i, cluster := range clusters {
-		style := lipgloss.NewStyle().Foreground(lipgloss.Color(colorToHex(colors[i])))
+		style := base.Foreground(lipgloss.Color(colorToHex(colors[i])))
 		if bold {
 			style = style.Bold(true)
 		}

--- a/internal/ui/styles/panel.go
+++ b/internal/ui/styles/panel.go
@@ -9,8 +9,12 @@ func PanelStyle(focused bool) lipgloss.Style {
 	if focused {
 		borderColor = t.BorderFocus
 	}
-	return lipgloss.NewStyle().
+	s := t.BaseStyle().
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
 		Foreground(t.FgBase)
+	if t.HasExplicitBackground {
+		s = s.BorderBackground(t.BgBase)
+	}
+	return s
 }

--- a/internal/ui/styles/theme.go
+++ b/internal/ui/styles/theme.go
@@ -84,21 +84,39 @@ func (t *Theme) S() *Styles {
 }
 
 func (t *Theme) buildStyles() *Styles {
-	base := lipgloss.NewStyle().Foreground(t.FgBase)
+	bg := t.baseStyle()
+	base := bg.Foreground(t.FgBase)
 
 	return &Styles{
 		Base:   base,
-		Muted:  lipgloss.NewStyle().Foreground(t.FgMuted),
-		Subtle: lipgloss.NewStyle().Foreground(t.FgSubtle),
+		Muted:  bg.Foreground(t.FgMuted),
+		Subtle: bg.Foreground(t.FgSubtle),
 		Title:  base.Bold(true),
-		Playing: lipgloss.NewStyle().
+		Playing: bg.
 			Foreground(t.Primary).
 			Bold(true),
-		Cursor: lipgloss.NewStyle().
+		Cursor: bg.
 			Background(t.BgCursor).
 			Foreground(t.FgBase),
-		Success: lipgloss.NewStyle().Foreground(t.Success),
-		Error:   lipgloss.NewStyle().Foreground(t.Error),
-		Warning: lipgloss.NewStyle().Foreground(t.Warning),
+		Success: bg.Foreground(t.Success),
+		Error:   bg.Foreground(t.Error),
+		Warning: bg.Foreground(t.Warning),
 	}
+}
+
+// baseStyle returns a style with the background set if the theme has an
+// explicit background, or an empty style otherwise.
+func (t *Theme) baseStyle() lipgloss.Style {
+	s := lipgloss.NewStyle()
+	if t.HasExplicitBackground {
+		s = s.Background(t.BgBase)
+	}
+	return s
+}
+
+// BaseStyle returns a lipgloss.Style pre-configured with the theme background
+// when an explicit background is set. Use this instead of lipgloss.NewStyle()
+// in UI components to ensure consistent background rendering.
+func (t *Theme) BaseStyle() lipgloss.Style {
+	return t.baseStyle()
 }

--- a/internal/ui/styles/theme.go
+++ b/internal/ui/styles/theme.go
@@ -26,6 +26,10 @@ type Theme struct {
 	Error   lipgloss.Color // Red - errors, removed
 	Warning lipgloss.Color // Yellow/orange - warnings
 
+	// HasExplicitBackground is true when the user explicitly set a background color.
+	// When false, the terminal's native background is used.
+	HasExplicitBackground bool
+
 	styles *Styles
 }
 

--- a/internal/ui/styles/theme.go
+++ b/internal/ui/styles/theme.go
@@ -120,3 +120,12 @@ func (t *Theme) baseStyle() lipgloss.Style {
 func (t *Theme) BaseStyle() lipgloss.Style {
 	return t.baseStyle()
 }
+
+// Bg applies the theme background to unstyled text (spaces, separators, etc.)
+// when an explicit background is set. Returns the text unchanged otherwise.
+func (t *Theme) Bg(s string) string {
+	if t.HasExplicitBackground {
+		return t.baseStyle().Render(s)
+	}
+	return s
+}

--- a/internal/ui/styles/theme_config.go
+++ b/internal/ui/styles/theme_config.go
@@ -64,11 +64,15 @@ func NewTheme(cfg config.ThemeConfig) (*Theme, error) {
 		o.apply(lipgloss.Color(expandHex(*o.value)))
 	}
 
-	// Derive FgSubtle: blend muted 30% toward background
-	t.FgSubtle = blendHex(t.FgMuted, t.BgBase, 0.3)
+	// Derive FgSubtle only if muted or background changed
+	if cfg.Muted != nil || cfg.Background != nil {
+		t.FgSubtle = blendHex(t.FgMuted, t.BgBase, 0.3)
+	}
 
-	// Derive BgCursor: blend background 15% toward text
-	t.BgCursor = blendHex(t.BgBase, t.FgBase, 0.15)
+	// Derive BgCursor only if background or text changed
+	if cfg.Background != nil || cfg.Text != nil {
+		t.BgCursor = blendHex(t.BgBase, t.FgBase, 0.15)
+	}
 
 	return &t, nil
 }

--- a/internal/ui/styles/theme_config.go
+++ b/internal/ui/styles/theme_config.go
@@ -1,0 +1,82 @@
+package styles
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/lucasb-eyer/go-colorful"
+
+	"github.com/llehouerou/waves/internal/config"
+)
+
+var hexColorRe = regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`)
+
+func validateHexColor(field, value string) error {
+	if !hexColorRe.MatchString(value) {
+		return fmt.Errorf(
+			"invalid theme color %q: %q is not a valid hex color (#RGB or #RRGGBB)",
+			field, value,
+		)
+	}
+	return nil
+}
+
+// expandHex converts short hex (#RGB) to full hex (#RRGGBB).
+// Assumes input is already validated.
+func expandHex(hex string) string {
+	if len(hex) == 4 {
+		return "#" + string(hex[1]) + string(hex[1]) +
+			string(hex[2]) + string(hex[2]) +
+			string(hex[3]) + string(hex[3])
+	}
+	return hex
+}
+
+// NewTheme creates a Theme from user config, applying defaults and deriving
+// technical colors. Returns an error if any provided color is invalid.
+func NewTheme(cfg config.ThemeConfig) (*Theme, error) {
+	t := defaultTheme
+	t.styles = nil // reset cached styles
+
+	type override struct {
+		field string
+		value *string
+		apply func(lipgloss.Color)
+	}
+
+	overrides := []override{
+		{"accent", cfg.Accent, func(c lipgloss.Color) { t.Primary = c; t.BorderFocus = c }},
+		{"secondary", cfg.Secondary, func(c lipgloss.Color) { t.Secondary = c; t.Warning = c }},
+		{"text", cfg.Text, func(c lipgloss.Color) { t.FgBase = c }},
+		{"muted", cfg.Muted, func(c lipgloss.Color) { t.FgMuted = c }},
+		{"background", cfg.Background, func(c lipgloss.Color) { t.BgBase = c }},
+		{"border", cfg.Border, func(c lipgloss.Color) { t.Border = c }},
+	}
+
+	for _, o := range overrides {
+		if o.value == nil {
+			continue
+		}
+		if err := validateHexColor(o.field, *o.value); err != nil {
+			return nil, err
+		}
+		o.apply(lipgloss.Color(expandHex(*o.value)))
+	}
+
+	// Derive FgSubtle: blend muted 30% toward background
+	t.FgSubtle = blendHex(t.FgMuted, t.BgBase, 0.3)
+
+	// Derive BgCursor: blend background 15% toward text
+	t.BgCursor = blendHex(t.BgBase, t.FgBase, 0.15)
+
+	return &t, nil
+}
+
+// blendHex blends two lipgloss colors in HCL space and returns the result.
+func blendHex(from, to lipgloss.Color, t float64) lipgloss.Color {
+	c1, _ := colorful.Hex(string(from))
+	c2, _ := colorful.Hex(string(to))
+	blended := c1.BlendHcl(c2, t)
+	return lipgloss.Color(blended.Clamped().Hex())
+}

--- a/internal/ui/styles/theme_config.go
+++ b/internal/ui/styles/theme_config.go
@@ -77,6 +77,17 @@ func NewTheme(cfg config.ThemeConfig) (*Theme, error) {
 	return &t, nil
 }
 
+// InitTheme builds a Theme from user config and sets it as the global theme.
+// Must be called before any UI rendering. Returns an error if config is invalid.
+func InitTheme(cfg config.ThemeConfig) error {
+	theme, err := NewTheme(cfg)
+	if err != nil {
+		return err
+	}
+	defaultTheme = *theme
+	return nil
+}
+
 // blendHex blends two lipgloss colors in HCL space and returns the result.
 func blendHex(from, to lipgloss.Color, t float64) lipgloss.Color {
 	c1, _ := colorful.Hex(string(from))

--- a/internal/ui/styles/theme_config.go
+++ b/internal/ui/styles/theme_config.go
@@ -50,7 +50,7 @@ func NewTheme(cfg config.ThemeConfig) (*Theme, error) {
 		{"secondary", cfg.Secondary, func(c lipgloss.Color) { t.Secondary = c; t.Warning = c }},
 		{"text", cfg.Text, func(c lipgloss.Color) { t.FgBase = c }},
 		{"muted", cfg.Muted, func(c lipgloss.Color) { t.FgMuted = c }},
-		{"background", cfg.Background, func(c lipgloss.Color) { t.BgBase = c }},
+		{"background", cfg.Background, func(c lipgloss.Color) { t.BgBase = c; t.HasExplicitBackground = true }},
 		{"border", cfg.Border, func(c lipgloss.Color) { t.Border = c }},
 	}
 

--- a/internal/ui/styles/theme_config_test.go
+++ b/internal/ui/styles/theme_config_test.go
@@ -101,14 +101,11 @@ func TestNewTheme_EmptyConfig(t *testing.T) {
 	if theme.Warning != def.Warning {
 		t.Errorf("Warning = %q, want %q", theme.Warning, def.Warning)
 	}
-	// FgSubtle and BgCursor are derived via HCL blending from the default
-	// values, so they may differ slightly from the hardcoded defaults.
-	// Just check they are non-empty.
-	if theme.FgSubtle == "" {
-		t.Error("FgSubtle should not be empty")
+	if theme.FgSubtle != def.FgSubtle {
+		t.Errorf("FgSubtle = %q, want %q", theme.FgSubtle, def.FgSubtle)
 	}
-	if theme.BgCursor == "" {
-		t.Error("BgCursor should not be empty")
+	if theme.BgCursor != def.BgCursor {
+		t.Errorf("BgCursor = %q, want %q", theme.BgCursor, def.BgCursor)
 	}
 }
 

--- a/internal/ui/styles/theme_config_test.go
+++ b/internal/ui/styles/theme_config_test.go
@@ -210,3 +210,50 @@ func TestNewTheme_InvalidColor(t *testing.T) {
 		t.Error("NewTheme() expected error for invalid color, got nil")
 	}
 }
+
+func TestInitTheme(t *testing.T) {
+	// Save original and restore after test
+	original := defaultTheme
+	defer func() { defaultTheme = original }()
+
+	accent := "#ff0000"
+	err := InitTheme(config.ThemeConfig{Accent: &accent})
+	if err != nil {
+		t.Fatalf("InitTheme() error = %v", err)
+	}
+
+	// T() should now return the customised theme
+	if T().Primary != "#ff0000" {
+		t.Errorf("T().Primary = %q, want #ff0000", T().Primary)
+	}
+}
+
+func TestInitTheme_EmptyConfig(t *testing.T) {
+	original := defaultTheme
+	defer func() { defaultTheme = original }()
+
+	err := InitTheme(config.ThemeConfig{})
+	if err != nil {
+		t.Fatalf("InitTheme() error = %v", err)
+	}
+
+	if T().Primary != original.Primary {
+		t.Errorf("T().Primary = %q, want %q", T().Primary, original.Primary)
+	}
+}
+
+func TestInitTheme_InvalidColor(t *testing.T) {
+	original := defaultTheme
+	defer func() { defaultTheme = original }()
+
+	bad := "invalid"
+	err := InitTheme(config.ThemeConfig{Accent: &bad})
+	if err == nil {
+		t.Error("InitTheme() expected error for invalid color")
+	}
+
+	// Theme should not have changed
+	if T().Primary != original.Primary {
+		t.Errorf("T().Primary changed after error: %q, want %q", T().Primary, original.Primary)
+	}
+}

--- a/internal/ui/styles/theme_config_test.go
+++ b/internal/ui/styles/theme_config_test.go
@@ -107,6 +107,9 @@ func TestNewTheme_EmptyConfig(t *testing.T) {
 	if theme.BgCursor != def.BgCursor {
 		t.Errorf("BgCursor = %q, want %q", theme.BgCursor, def.BgCursor)
 	}
+	if theme.HasExplicitBackground {
+		t.Error("HasExplicitBackground should be false for empty config")
+	}
 }
 
 func TestNewTheme_AllOverrides(t *testing.T) {
@@ -167,6 +170,9 @@ func TestNewTheme_AllOverrides(t *testing.T) {
 	// Derived: BgCursor should be between background and text
 	if theme.BgCursor == theme.BgBase || theme.BgCursor == theme.FgBase {
 		t.Errorf("BgCursor = %q, expected a blend between background and text", theme.BgCursor)
+	}
+	if !theme.HasExplicitBackground {
+		t.Error("HasExplicitBackground should be true when background is set")
 	}
 }
 

--- a/internal/ui/styles/theme_config_test.go
+++ b/internal/ui/styles/theme_config_test.go
@@ -1,0 +1,215 @@
+package styles
+
+import (
+	"testing"
+
+	"github.com/llehouerou/waves/internal/config"
+)
+
+const (
+	testRed   = "#ff0000"
+	testGreen = "#00ff00"
+)
+
+func TestValidateHexColor(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		value   string
+		wantErr bool
+	}{
+		{"valid 6-digit", "accent", testRed, false},
+		{"valid 3-digit", "accent", "#f00", false},
+		{"valid lowercase", "accent", "#abcdef", false},
+		{"valid uppercase", "accent", "#ABCDEF", false},
+		{"valid mixed case", "accent", "#aBcDeF", false},
+		{"missing hash", "accent", "ff0000", true},
+		{"too short", "accent", "#ff00", true},
+		{"too long", "accent", "#ff00000", true},
+		{"invalid chars", "accent", "#gggggg", true},
+		{"empty", "accent", "", true},
+		{"just hash", "accent", "#", true},
+		{"not hex at all", "border", "red", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHexColor(tt.field, tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateHexColor(%q, %q) error = %v, wantErr %v", tt.field, tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExpandHex(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"#abc", "#aabbcc"},
+		{"#ABC", "#AABBCC"},
+		{"#f00", testRed},
+		{"#abcdef", "#abcdef"},
+		{"#ABCDEF", "#ABCDEF"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := expandHex(tt.input)
+			if got != tt.want {
+				t.Errorf("expandHex(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewTheme_EmptyConfig(t *testing.T) {
+	theme, err := NewTheme(config.ThemeConfig{})
+	if err != nil {
+		t.Fatalf("NewTheme() error = %v", err)
+	}
+
+	def := defaultTheme
+	if theme.Primary != def.Primary {
+		t.Errorf("Primary = %q, want %q", theme.Primary, def.Primary)
+	}
+	if theme.Secondary != def.Secondary {
+		t.Errorf("Secondary = %q, want %q", theme.Secondary, def.Secondary)
+	}
+	if theme.FgBase != def.FgBase {
+		t.Errorf("FgBase = %q, want %q", theme.FgBase, def.FgBase)
+	}
+	if theme.FgMuted != def.FgMuted {
+		t.Errorf("FgMuted = %q, want %q", theme.FgMuted, def.FgMuted)
+	}
+	if theme.BgBase != def.BgBase {
+		t.Errorf("BgBase = %q, want %q", theme.BgBase, def.BgBase)
+	}
+	if theme.Border != def.Border {
+		t.Errorf("Border = %q, want %q", theme.Border, def.Border)
+	}
+	if theme.BorderFocus != def.BorderFocus {
+		t.Errorf("BorderFocus = %q, want %q", theme.BorderFocus, def.BorderFocus)
+	}
+	if theme.Success != def.Success {
+		t.Errorf("Success = %q, want %q", theme.Success, def.Success)
+	}
+	if theme.Error != def.Error {
+		t.Errorf("Error = %q, want %q", theme.Error, def.Error)
+	}
+	if theme.Warning != def.Warning {
+		t.Errorf("Warning = %q, want %q", theme.Warning, def.Warning)
+	}
+	// FgSubtle and BgCursor are derived via HCL blending from the default
+	// values, so they may differ slightly from the hardcoded defaults.
+	// Just check they are non-empty.
+	if theme.FgSubtle == "" {
+		t.Error("FgSubtle should not be empty")
+	}
+	if theme.BgCursor == "" {
+		t.Error("BgCursor should not be empty")
+	}
+}
+
+func TestNewTheme_AllOverrides(t *testing.T) {
+	accent := testRed
+	secondary := testGreen
+	text := "#ffffff"
+	muted := "#888888"
+	bg := "#000000"
+	border := "#444444"
+
+	theme, err := NewTheme(config.ThemeConfig{
+		Accent:     &accent,
+		Secondary:  &secondary,
+		Text:       &text,
+		Muted:      &muted,
+		Background: &bg,
+		Border:     &border,
+	})
+	if err != nil {
+		t.Fatalf("NewTheme() error = %v", err)
+	}
+
+	// Direct mappings
+	if theme.Primary != testRed {
+		t.Errorf("Primary = %q, want %s", theme.Primary, testRed)
+	}
+	if theme.Secondary != testGreen {
+		t.Errorf("Secondary = %q, want %s", theme.Secondary, testGreen)
+	}
+	if theme.FgBase != "#ffffff" {
+		t.Errorf("FgBase = %q, want #ffffff", theme.FgBase)
+	}
+	if theme.FgMuted != "#888888" {
+		t.Errorf("FgMuted = %q, want #888888", theme.FgMuted)
+	}
+	if theme.BgBase != "#000000" {
+		t.Errorf("BgBase = %q, want #000000", theme.BgBase)
+	}
+	if theme.Border != "#444444" {
+		t.Errorf("Border = %q, want #444444", theme.Border)
+	}
+	if theme.BorderFocus != testRed {
+		t.Errorf("BorderFocus = %q, want %s", theme.BorderFocus, testRed)
+	}
+	if theme.Warning != testGreen {
+		t.Errorf("Warning = %q, want %s", theme.Warning, testGreen)
+	}
+	if theme.Success != defaultTheme.Success {
+		t.Errorf("Success = %q, want %q", theme.Success, defaultTheme.Success)
+	}
+	if theme.Error != defaultTheme.Error {
+		t.Errorf("Error = %q, want %q", theme.Error, defaultTheme.Error)
+	}
+	// Derived: FgSubtle should be between muted and background
+	if theme.FgSubtle == theme.FgMuted || theme.FgSubtle == theme.BgBase {
+		t.Errorf("FgSubtle = %q, expected a blend between muted and background", theme.FgSubtle)
+	}
+	// Derived: BgCursor should be between background and text
+	if theme.BgCursor == theme.BgBase || theme.BgCursor == theme.FgBase {
+		t.Errorf("BgCursor = %q, expected a blend between background and text", theme.BgCursor)
+	}
+}
+
+func TestNewTheme_SingleOverride(t *testing.T) {
+	accent := testRed
+	theme, err := NewTheme(config.ThemeConfig{Accent: &accent})
+	if err != nil {
+		t.Fatalf("NewTheme() error = %v", err)
+	}
+
+	if theme.Primary != testRed {
+		t.Errorf("Primary = %q, want %s", theme.Primary, testRed)
+	}
+	if theme.BorderFocus != testRed {
+		t.Errorf("BorderFocus = %q, want %s", theme.BorderFocus, testRed)
+	}
+	if theme.Secondary != defaultTheme.Secondary {
+		t.Errorf("Secondary = %q, want default %q", theme.Secondary, defaultTheme.Secondary)
+	}
+	if theme.FgBase != defaultTheme.FgBase {
+		t.Errorf("FgBase = %q, want default %q", theme.FgBase, defaultTheme.FgBase)
+	}
+}
+
+func TestNewTheme_ShortHex(t *testing.T) {
+	accent := "#f00"
+	theme, err := NewTheme(config.ThemeConfig{Accent: &accent})
+	if err != nil {
+		t.Fatalf("NewTheme() error = %v", err)
+	}
+
+	if theme.Primary != testRed {
+		t.Errorf("Primary = %q, want %s", theme.Primary, testRed)
+	}
+}
+
+func TestNewTheme_InvalidColor(t *testing.T) {
+	bad := "not-a-color"
+	_, err := NewTheme(config.ThemeConfig{Accent: &bad})
+	if err == nil {
+		t.Error("NewTheme() expected error for invalid color, got nil")
+	}
+}

--- a/internal/ui/textinput/textinput.go
+++ b/internal/ui/textinput/textinput.go
@@ -18,7 +18,7 @@ func inputStyle() lipgloss.Style {
 }
 
 func titleStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
+	return styles.T().BaseStyle().
 		Bold(true).
 		Foreground(styles.T().Primary)
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llehouerou/waves/internal/icons"
 	"github.com/llehouerou/waves/internal/state"
 	"github.com/llehouerou/waves/internal/stderr"
+	"github.com/llehouerou/waves/internal/ui/styles"
 )
 
 var version = "dev"
@@ -32,6 +33,11 @@ func run() int {
 	cfg, err := config.Load()
 	if err != nil {
 		stderr.WriteOriginal(fmt.Sprintf("Error loading config: %v\n", err))
+		return 1
+	}
+
+	if err := styles.InitTheme(cfg.Theme); err != nil {
+		stderr.WriteOriginal(fmt.Sprintf("Error loading theme: %v\n", err))
 		return 1
 	}
 


### PR DESCRIPTION
## Summary

Closes #19

- Add `[theme]` section to `config.toml` with 6 user-facing colors: `accent`, `secondary`, `text`, `muted`, `background`, `border`
- Remaining 6 internal colors are derived automatically (e.g. `border_focus` = accent, `bg_cursor` = background blended toward text in HCL space)
- When `background` is explicitly set, it is applied as the actual terminal background across all UI components; when omitted, the terminal's native background is used (preserving existing behavior)
- All colors are validated at startup (hex format `#RGB` or `#RRGGBB`), with clear error messages on invalid input

### Example config

```toml
[theme]
accent     = "#8839ef"
secondary  = "#df8e1d"
text       = "#4c4f69"
muted      = "#9ca0b0"
background = "#eff1f5"
border     = "#bcc0cc"
```

## Test plan

- [x] No `[theme]` section → identical behavior to before
- [x] Partial overrides (e.g. only `accent`) → only affected colors change
- [x] Full theme with dark background → all components render correctly
- [x] Full theme with light background → background applied everywhere
- [x] Invalid color value → clear startup error, app does not start
- [x] `go test ./internal/config/ ./internal/ui/styles/ -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)