### PR TITLE
fix(app): bound tick chain to one owner — high CPU that builds up (#28)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -74,7 +74,12 @@ type Model struct {
 	LastVolumeScrollTime time.Time // Debounce for mouse wheel volume control
 	PendingTrackIdx      int
 	TrackSkipVersion     int
-	Favorites            map[int64]bool // Track IDs that are favorited
+	// Tick lifecycle (issue #28): tickGen is the only currently-valid tick
+	// generation; tickRunning is true while a chain is alive. Together they
+	// guarantee at most one live 1s tick chain. Mutate only via tick.go.
+	tickGen     int
+	tickRunning bool
+	Favorites   map[int64]bool // Track IDs that are favorited
 
 	// Last.fm scrobbling
 	Lastfm          *lastfm.Client       // nil if not configured

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -180,7 +180,7 @@ func TestUpdate_TickMsg_ContinuesWhenPlaying(t *testing.T) {
 	}
 	mock.SetState(player.Playing)
 
-	_, cmd := m.Update(TickMsg{})
+	_, cmd := m.Update(TickMsg{Gen: m.tickGen})
 
 	if cmd == nil {
 		t.Error("expected tick command to continue")
@@ -191,7 +191,7 @@ func TestUpdate_TickMsg_StopsWhenNotPlaying(t *testing.T) {
 	m := newIntegrationTestModel()
 	// Player is stopped by default
 
-	_, cmd := m.Update(TickMsg{})
+	_, cmd := m.Update(TickMsg{Gen: m.tickGen})
 
 	if cmd != nil {
 		t.Error("expected no tick command when stopped")

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -13,10 +13,10 @@ import (
 	"github.com/llehouerou/waves/internal/stderr"
 )
 
-// TickCmd returns a command that sends TickMsg after 1 second.
-func TickCmd() tea.Cmd {
+// TickCmd returns a command that sends a TickMsg tagged with gen after 1s.
+func TickCmd(gen int) tea.Cmd {
 	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
-		return TickMsg(t)
+		return TickMsg{Gen: gen, Time: t}
 	})
 }
 

--- a/internal/app/cpu_tick_repro_test.go
+++ b/internal/app/cpu_tick_repro_test.go
@@ -116,7 +116,7 @@ func TestCPU_TickChainsAccumulatePerTrackChange(t *testing.T) {
 		}
 
 		// 3. Each chain is self-sustaining: one TickMsg re-arms exactly one tick.
-		_, tickCmd := updateModel(t, m, TickMsg(time.Now()))
+		_, tickCmd := updateModel(t, m, TickMsg{Gen: m.tickGen, Time: time.Now()})
 		if got := countTickChains(t, tickCmd); got != 1 {
 			t.Fatalf("a TickMsg while playing should re-arm exactly 1 tick, got %d", got)
 		}

--- a/internal/app/cpu_tick_repro_test.go
+++ b/internal/app/cpu_tick_repro_test.go
@@ -1,0 +1,133 @@
+// internal/app/cpu_tick_repro_test.go
+//
+// Reproduction for issue #28 ("high cpu usage", builds up over time).
+//
+// Hypothesis: every track change while playing seeds a NEW, independent,
+// self-sustaining 1-second TickCmd chain. Nothing ever cancels old chains, so
+// the number of concurrent tickers grows by one on every track change. Each
+// tick triggers a full Update+View, so per-second CPU work grows linearly with
+// the number of tracks played in a session.
+//
+// This test drives the real Model.Update and counts how many independent
+// TickMsg-producing chains are live. It uses testing/synctest so tea.Tick
+// timers resolve deterministically in virtual time.
+package app
+
+import (
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/llehouerou/waves/internal/playback"
+	"github.com/llehouerou/waves/internal/player"
+)
+
+// countTickChains executes cmd (recursively flattening tea.Batch) under
+// synctest virtual time and returns how many leaf commands resolve to a
+// TickMsg. Each such leaf is one independent self-sustaining ticker chain.
+//
+// Leaves that stay durably blocked (e.g. WatchServiceEvents waiting on the
+// subscription) produce no result and are not counted. Immediate non-tick
+// leaves (e.g. the AlbumArtUpdateMsg closure) are ignored.
+func countTickChains(t *testing.T, cmd tea.Cmd) int {
+	t.Helper()
+	if cmd == nil {
+		return 0
+	}
+	var (
+		mu    sync.Mutex
+		count int
+	)
+	var walk func(c tea.Cmd)
+	walk = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		res := make(chan tea.Msg, 1)
+		go func() {
+			defer func() { _ = recover() }()
+			res <- c()
+		}()
+		// Advance virtual time past TickCmd's 1s tea.Tick timer. A timer-blocked
+		// goroutine is "durably blocked", so synctest.Wait() alone returns before
+		// it fires; sleeping in virtual time lets the fake clock advance and the
+		// leaf resolve. Non-tick leaves either resolve immediately or stay
+		// durably blocked (WatchServiceEvents) and fall through to default.
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		select {
+		case msg := <-res:
+			switch m := msg.(type) {
+			case tea.BatchMsg:
+				for _, sub := range m {
+					walk(sub)
+				}
+			case TickMsg:
+				mu.Lock()
+				count++
+				mu.Unlock()
+			}
+		default:
+			// Leaf still durably blocked (e.g. WatchServiceEvents): not a tick.
+		}
+	}
+	walk(cmd)
+	return count
+}
+
+func TestCPU_TickChainsAccumulatePerTrackChange(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		m := newIntegrationTestModel()
+		defer func() {
+			_ = m.PlaybackService.Close()
+			synctest.Wait() // let blocked WatchServiceEvents goroutines exit
+		}()
+
+		m.PlaybackService.AddTracks(
+			playback.Track{Path: "/a.mp3", Artist: "A", Title: "A", Album: "Alb"},
+			playback.Track{Path: "/b.mp3", Artist: "B", Title: "B", Album: "Alb"},
+		)
+		mock, ok := m.PlaybackService.Player().(*player.Mock)
+		if !ok {
+			t.Fatal("expected mock player")
+		}
+		mock.SetState(player.Playing)
+
+		// 1. Playback starts (stopped -> playing) seeds the first tick chain.
+		mdl, cmd := updateModel(t, m, ServiceStateChangedMsg{
+			Previous: int(playback.StateStopped),
+			Current:  int(playback.StatePlaying),
+		})
+		m = mdl
+		chains := countTickChains(t, cmd)
+
+		// 2. Each track change while playing seeds ANOTHER chain (the bug).
+		const trackChanges = 20
+		for range trackChanges {
+			mdl, cmd = updateModel(t, m, ServiceTrackChangedMsg{
+				PreviousIndex: 0,
+				CurrentIndex:  1,
+			})
+			m = mdl
+			chains += countTickChains(t, cmd)
+		}
+
+		// 3. Each chain is self-sustaining: one TickMsg re-arms exactly one tick.
+		_, tickCmd := updateModel(t, m, TickMsg(time.Now()))
+		if got := countTickChains(t, tickCmd); got != 1 {
+			t.Fatalf("a TickMsg while playing should re-arm exactly 1 tick, got %d", got)
+		}
+
+		// With `trackChanges` transitions the Bubble Tea runtime now delivers
+		// `chains` TickMsgs every second, each causing a full Update+View.
+		if chains != 1 {
+			t.Fatalf(
+				"tick chains = %d after %d track changes => %d Update+View per second (want 1, bounded).\n"+
+					"CPU grows linearly with the number of tracks played in a session (issue #28).",
+				chains, trackChanges, chains)
+		}
+	})
+}

--- a/internal/app/cpu_tick_repro_test.go
+++ b/internal/app/cpu_tick_repro_test.go
@@ -56,6 +56,8 @@ func countTickChains(t *testing.T, cmd tea.Cmd) int {
 		// it fires; sleeping in virtual time lets the fake clock advance and the
 		// leaf resolve. Non-tick leaves either resolve immediately or stay
 		// durably blocked (WatchServiceEvents) and fall through to default.
+		// NOTE: this sleep must exceed TickCmd's interval (commands.go,
+		// time.Second); keep them in sync if that period ever changes.
 		time.Sleep(2 * time.Second)
 		synctest.Wait()
 		select {

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -48,7 +48,12 @@ type LibraryScanMessage interface {
 }
 
 // TickMsg is sent periodically to update the UI (e.g., progress bar).
-type TickMsg time.Time
+// Gen identifies the tick chain that produced it so stale chains are dropped
+// (issue #28; see internal/app/tick.go and the TickMsg handler).
+type TickMsg struct {
+	Gen  int
+	Time time.Time
+}
 
 func (TickMsg) playbackMessage() {}
 

--- a/internal/app/playback.go
+++ b/internal/app/playback.go
@@ -35,10 +35,10 @@ func (m *Model) PlayTrack(path string) tea.Cmd {
 
 	// Trigger radio fill when starting the last track (pre-fetch next tracks)
 	if radioCmd := m.triggerRadioFill(); radioCmd != nil {
-		return tea.Batch(TickCmd(), radioCmd)
+		return tea.Batch(m.ensureTickRunning(), radioCmd)
 	}
 
-	return TickCmd()
+	return m.ensureTickRunning()
 }
 
 // HandleSpaceAction handles the space key: toggle pause/resume or start playback.

--- a/internal/app/tick.go
+++ b/internal/app/tick.go
@@ -23,3 +23,11 @@ func (m *Model) stopTick() {
 	m.tickRunning = false
 	m.tickGen++
 }
+
+// clearRunning marks the chain as ended WITHOUT bumping the generation.
+// Use when a chain dies naturally (a TickMsg observed that playback is no
+// longer active). Use stopTick instead when playback is stopped externally,
+// so in-flight ticks from the old generation are also invalidated.
+func (m *Model) clearRunning() {
+	m.tickRunning = false
+}

--- a/internal/app/tick.go
+++ b/internal/app/tick.go
@@ -1,0 +1,25 @@
+// internal/app/tick.go
+package app
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// ensureTickRunning starts a single 1s tick chain if none is alive.
+// It returns nil when a chain is already running, which is what prevents the
+// per-track accumulation in issue #28. The returned command, if any, must be
+// scheduled by the caller; the mutated Model must be returned (MVU).
+func (m *Model) ensureTickRunning() tea.Cmd {
+	if m.tickRunning {
+		return nil
+	}
+	m.tickRunning = true
+	m.tickGen++
+	return TickCmd(m.tickGen)
+}
+
+// stopTick invalidates the current tick chain. Any TickMsg still in flight
+// from the old generation is dropped by the generation check in the TickMsg
+// handler, so no stale chain can survive a stop.
+func (m *Model) stopTick() {
+	m.tickRunning = false
+	m.tickGen++
+}

--- a/internal/app/tick_lifecycle_test.go
+++ b/internal/app/tick_lifecycle_test.go
@@ -71,17 +71,21 @@ func TestCPU_TickChainSurvivesTransitions(t *testing.T) {
 		if got := countTickChains(t, pausedCmd); got != 0 {
 			t.Fatalf("tick while paused re-armed %d chains, want 0", got)
 		}
-		// The model copy returned by that tick must have cleared tickRunning.
+		// Two observations of the same paused transition: the first call
+		// above confirmed no re-arm command; this one confirms the returned
+		// model has tickRunning cleared.
 		mdl, _ = updateModel(t, m, TickMsg{Gen: m.tickGen, Time: time.Now()})
 		m = mdl
 		if m.tickRunning {
 			t.Fatal("tickRunning should be false after a tick while paused")
 		}
 
-		// Resume -> exactly one chain again.
+		// Resume -> exactly one chain again. The real service emits
+		// Previous: StatePaused on resume; handleServiceStateChanged only
+		// special-cases StateStopped, so paused/playing take the same path.
 		mock.SetState(player.Playing)
 		mdl, cmd = updateModel(t, m, ServiceStateChangedMsg{
-			Previous: int(playback.StatePlaying), // resume from paused
+			Previous: int(playback.StatePaused),
 			Current:  int(playback.StatePlaying),
 		})
 		m = mdl

--- a/internal/app/tick_lifecycle_test.go
+++ b/internal/app/tick_lifecycle_test.go
@@ -1,0 +1,92 @@
+// internal/app/tick_lifecycle_test.go
+//
+// Regression for issue #28: exactly one tick chain survives playback
+// transitions (stop->play, pause->resume). Reuses countTickChains from
+// cpu_tick_repro_test.go.
+package app
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/llehouerou/waves/internal/playback"
+	"github.com/llehouerou/waves/internal/player"
+)
+
+func TestCPU_TickChainSurvivesTransitions(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		m := newIntegrationTestModel()
+		defer func() {
+			_ = m.PlaybackService.Close()
+			synctest.Wait()
+		}()
+
+		m.PlaybackService.AddTracks(
+			playback.Track{Path: "/a.mp3", Artist: "A", Title: "A", Album: "Alb"},
+		)
+		mock, ok := m.PlaybackService.Player().(*player.Mock)
+		if !ok {
+			t.Fatal("expected mock player")
+		}
+
+		// Play -> exactly one chain.
+		mock.SetState(player.Playing)
+		mdl, cmd := updateModel(t, m, ServiceStateChangedMsg{
+			Previous: int(playback.StateStopped),
+			Current:  int(playback.StatePlaying),
+		})
+		m = mdl
+		if got := countTickChains(t, cmd); got != 1 {
+			t.Fatalf("after play: chains = %d, want 1", got)
+		}
+
+		// Stop -> the chain's next TickMsg (old gen) must not re-arm.
+		staleGen := m.tickGen
+		mock.SetState(player.Stopped)
+		mdl, _ = updateModel(t, m, ServiceStateChangedMsg{
+			Previous: int(playback.StatePlaying),
+			Current:  int(playback.StateStopped),
+		})
+		m = mdl
+		_, staleCmd := updateModel(t, m, TickMsg{Gen: staleGen, Time: time.Now()})
+		if got := countTickChains(t, staleCmd); got != 0 {
+			t.Fatalf("stale tick after stop re-armed %d chains, want 0", got)
+		}
+
+		// Play again -> exactly one fresh chain (not zero, not two).
+		mock.SetState(player.Playing)
+		mdl, cmd = updateModel(t, m, ServiceStateChangedMsg{
+			Previous: int(playback.StateStopped),
+			Current:  int(playback.StatePlaying),
+		})
+		m = mdl
+		if got := countTickChains(t, cmd); got != 1 {
+			t.Fatalf("after stop->play: chains = %d, want 1", got)
+		}
+
+		// Pause: the current chain's tick sees !IsPlaying and ends itself.
+		mock.SetState(player.Paused)
+		_, pausedCmd := updateModel(t, m, TickMsg{Gen: m.tickGen, Time: time.Now()})
+		if got := countTickChains(t, pausedCmd); got != 0 {
+			t.Fatalf("tick while paused re-armed %d chains, want 0", got)
+		}
+		// The model copy returned by that tick must have cleared tickRunning.
+		mdl, _ = updateModel(t, m, TickMsg{Gen: m.tickGen, Time: time.Now()})
+		m = mdl
+		if m.tickRunning {
+			t.Fatal("tickRunning should be false after a tick while paused")
+		}
+
+		// Resume -> exactly one chain again.
+		mock.SetState(player.Playing)
+		mdl, cmd = updateModel(t, m, ServiceStateChangedMsg{
+			Previous: int(playback.StatePlaying), // resume from paused
+			Current:  int(playback.StatePlaying),
+		})
+		m = mdl
+		if got := countTickChains(t, cmd); got != 1 {
+			t.Fatalf("after pause->resume: chains = %d, want 1", got)
+		}
+	})
+}

--- a/internal/app/update_playback.go
+++ b/internal/app/update_playback.go
@@ -76,7 +76,7 @@ func (m Model) handlePlaybackMsg(msg PlaybackMessage) (tea.Model, tea.Cmd) {
 		}
 		if !m.PlaybackService.IsPlaying() {
 			// Playback no longer active (stopped/paused): end this chain.
-			m.tickRunning = false
+			m.clearRunning()
 			return m, nil
 		}
 		cmds := []tea.Cmd{TickCmd(m.tickGen)}

--- a/internal/app/update_playback.go
+++ b/internal/app/update_playback.go
@@ -69,20 +69,28 @@ func (m Model) handlePlaybackMsg(msg PlaybackMessage) (tea.Model, tea.Cmd) {
 	case TrackSkipTimeoutMsg:
 		return m.handleTrackSkipTimeout(msg)
 	case TickMsg:
-		if m.PlaybackService.IsPlaying() {
-			cmds := []tea.Cmd{TickCmd()}
-			if cmd := m.checkScrobbleThreshold(); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
-			if cmd := m.checkRadioFillNearEnd(); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
-			// Update lyrics position if popup is visible
-			if lyr := m.Popups.Lyrics(); lyr != nil {
-				lyr.SetPosition(m.PlaybackService.Player().Position())
-			}
-			return m, tea.Batch(cmds...)
+		// Drop ticks from a stale chain: only the current generation may
+		// re-arm, so at most one chain stays alive (issue #28).
+		if msg.Gen != m.tickGen {
+			return m, nil
 		}
+		if !m.PlaybackService.IsPlaying() {
+			// Playback no longer active (stopped/paused): end this chain.
+			m.tickRunning = false
+			return m, nil
+		}
+		cmds := []tea.Cmd{TickCmd(m.tickGen)}
+		if cmd := m.checkScrobbleThreshold(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		if cmd := m.checkRadioFillNearEnd(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		// Update lyrics position if popup is visible
+		if lyr := m.Popups.Lyrics(); lyr != nil {
+			lyr.SetPosition(m.PlaybackService.Player().Position())
+		}
+		return m, tea.Batch(cmds...)
 	}
 	return m, nil
 }
@@ -115,7 +123,7 @@ func (m Model) handleServiceStateChanged(msg ServiceStateChangedMsg) (tea.Model,
 // handlePlaybackStarted handles the transition to playing state.
 // fromStopped indicates if we're starting from a stopped state (first play).
 func (m Model) handlePlaybackStarted(fromStopped bool) (tea.Model, tea.Cmd) {
-	cmds := []tea.Cmd{TickCmd(), m.WatchServiceEvents()}
+	cmds := []tea.Cmd{m.ensureTickRunning(), m.WatchServiceEvents()}
 
 	// When starting from stopped, handle first track setup
 	// (TrackChange is not emitted for first play, only for track changes)
@@ -141,6 +149,7 @@ func (m Model) handlePlaybackStarted(fromStopped bool) (tea.Model, tea.Cmd) {
 
 // handlePlaybackStopped cleans up when playback stops.
 func (m *Model) handlePlaybackStopped() {
+	m.stopTick()
 	if m.AlbumArt != nil {
 		m.albumArtPendingTransmit = m.AlbumArt.Clear()
 	}
@@ -194,9 +203,9 @@ func (m Model) handleServiceTrackChanged(_ ServiceTrackChangedMsg) (tea.Model, t
 		cmds = append(cmds, cmd)
 	}
 
-	// Start tick command if playing
+	// Keep ticking if playing; no-op if a chain is already alive (issue #28).
 	if m.PlaybackService.IsPlaying() {
-		cmds = append(cmds, TickCmd())
+		cmds = append(cmds, m.ensureTickRunning())
 	}
 
 	return m, tea.Batch(cmds...)

--- a/internal/diag/pprof.go
+++ b/internal/diag/pprof.go
@@ -2,6 +2,8 @@
 //
 // Opt-in runtime profiling for issue #28 diagnostics. Nothing listens unless
 // WAVES_PPROF is set, so default builds carry zero overhead and no exposure.
+// Note: the blank net/http/pprof import always registers pprof handlers on
+// http.DefaultServeMux at init; only the listener is gated by WAVES_PPROF.
 package diag
 
 import (

--- a/internal/diag/pprof.go
+++ b/internal/diag/pprof.go
@@ -1,0 +1,27 @@
+// internal/diag/pprof.go
+//
+// Opt-in runtime profiling for issue #28 diagnostics. Nothing listens unless
+// WAVES_PPROF is set, so default builds carry zero overhead and no exposure.
+package diag
+
+import (
+	"net"
+	"net/http"
+	_ "net/http/pprof" //nolint:gosec // opt-in only; disabled unless WAVES_PPROF is set
+)
+
+// MaybeStartPprof opens a pprof HTTP server on addr in a background goroutine
+// when addr is non-empty. It returns whether a listener was opened and the
+// resolved address (useful when addr uses port 0). A non-empty addr that
+// fails to bind returns the error without crashing the app.
+func MaybeStartPprof(addr string) (started bool, actualAddr string, err error) {
+	if addr == "" {
+		return false, "", nil
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return false, "", err
+	}
+	go func() { _ = http.Serve(ln, nil) }() //nolint:gosec // opt-in diagnostic server, no timeouts needed
+	return true, ln.Addr().String(), nil
+}

--- a/internal/diag/pprof_test.go
+++ b/internal/diag/pprof_test.go
@@ -18,6 +18,9 @@ func TestMaybeStartPprof_ServesProfileIndex(t *testing.T) {
 	if err != nil || !started {
 		t.Fatalf("start: got (started=%v,addr=%q,err=%v)", started, addr, err)
 	}
+	// Listener and goroutine are intentionally not cleaned up: MaybeStartPprof
+	// has no shutdown API (YAGNI for a diagnostic tool); process exit is the
+	// cleanup. Do not add a t.Cleanup here — it cannot stop the server.
 	resp, err := http.Get("http://" + addr + "/debug/pprof/")
 	if err != nil {
 		t.Fatalf("GET pprof index: %v", err)

--- a/internal/diag/pprof_test.go
+++ b/internal/diag/pprof_test.go
@@ -1,0 +1,29 @@
+// internal/diag/pprof_test.go
+package diag
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMaybeStartPprof_DisabledWhenEmpty(t *testing.T) {
+	started, addr, err := MaybeStartPprof("")
+	if started || addr != "" || err != nil {
+		t.Fatalf("empty addr: got (%v,%q,%v), want (false,\"\",nil)", started, addr, err)
+	}
+}
+
+func TestMaybeStartPprof_ServesProfileIndex(t *testing.T) {
+	started, addr, err := MaybeStartPprof("127.0.0.1:0")
+	if err != nil || !started {
+		t.Fatalf("start: got (started=%v,addr=%q,err=%v)", started, addr, err)
+	}
+	resp, err := http.Get("http://" + addr + "/debug/pprof/")
+	if err != nil {
+		t.Fatalf("GET pprof index: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -33,12 +33,11 @@ func run() int {
 
 	// Opt-in profiling for issue #28 diagnostics. WAVES_PPROF=host:port
 	// (e.g. localhost:6060) starts net/http/pprof; unset => nothing listens.
-	if addr := os.Getenv("WAVES_PPROF"); addr != "" {
-		if ok, actual, perr := diag.MaybeStartPprof(addr); perr != nil {
-			stderr.WriteOriginal(fmt.Sprintf("WAVES_PPROF: %v\n", perr))
-		} else if ok {
-			stderr.WriteOriginal(fmt.Sprintf("pprof listening on http://%s/debug/pprof/\n", actual))
-		}
+	// MaybeStartPprof is a no-op for an empty address by contract.
+	if ok, actual, perr := diag.MaybeStartPprof(os.Getenv("WAVES_PPROF")); perr != nil {
+		stderr.WriteOriginal(fmt.Sprintf("WAVES_PPROF: failed to start pprof: %v\n", perr))
+	} else if ok {
+		stderr.WriteOriginal(fmt.Sprintf("pprof listening on http://%s/debug/pprof/\n", actual))
 	}
 
 	cfg, err := config.Load()

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/llehouerou/waves/internal/app"
 	"github.com/llehouerou/waves/internal/config"
+	"github.com/llehouerou/waves/internal/diag"
 	"github.com/llehouerou/waves/internal/icons"
 	"github.com/llehouerou/waves/internal/state"
 	"github.com/llehouerou/waves/internal/stderr"
@@ -29,6 +30,16 @@ func run() int {
 	// Capture stderr from C libraries (ALSA, minimp3) to prevent TUI corruption
 	_ = stderr.Start()
 	defer stderr.Stop()
+
+	// Opt-in profiling for issue #28 diagnostics. WAVES_PPROF=host:port
+	// (e.g. localhost:6060) starts net/http/pprof; unset => nothing listens.
+	if addr := os.Getenv("WAVES_PPROF"); addr != "" {
+		if ok, actual, perr := diag.MaybeStartPprof(addr); perr != nil {
+			stderr.WriteOriginal(fmt.Sprintf("WAVES_PPROF: %v\n", perr))
+		} else if ok {
+			stderr.WriteOriginal(fmt.Sprintf("pprof listening on http://%s/debug/pprof/\n", actual))
+		}
+	}
 
 	cfg, err := config.Load()
 	if err != nil {


### PR DESCRIPTION
## Summary

Addresses the **CPU half** of #28 (FreeBSD reporter: CPU "slowly builds up" to ~125%).

- **Root cause:** a new self-sustaining 1s `TickCmd` chain was seeded on every play/track-change and never cancelled, so per-second `Update`+`View` work grew linearly with tracks played.
- **Fix:** single-owner generation token on `Model` (`tickGen` + `tickRunning`). Seeds route through `ensureTickRunning()` (no-op while a chain is alive); `TickMsg` carries its generation and only the current generation re-arms; `stopTick()` bumps the generation so stale ticks die; `clearRunning()` ends a chain naturally on pause.
- **Diagnostics:** opt-in `WAVES_PPROF=host:port` pprof endpoint (off by default → zero overhead/exposure) so the reporter can confirm on FreeBSD and surface any residual contributor.
- **Scope:** `WatchServiceEvents` left untouched — verified 1-in-1-out, not a leak (de-scoped in the design). The missing cover-art half of #28 is tracked separately.

Commits: deterministic `testing/synctest` reproduction (`2d5d6b9`, was `21 chains` / 20 track changes) → fix → regression + transition tests → diagnostics → review nits.

## Test Plan

- [x] `TestCPU_TickChainsAccumulatePerTrackChange` — was RED (`21 chains`), now `chains == 1` after 20 track changes
- [x] `TestCPU_TickChainSurvivesTransitions` — exactly one chain across stop→play and pause→resume; stale-gen ticks never re-arm
- [x] `internal/diag` — `MaybeStartPprof` disabled when empty; serves `/debug/pprof/` (200) when set
- [x] `make check` (goimports + golangci-lint `0 issues`) and full `go test ./...` green; `-race` clean
- [ ] Reporter confirms on FreeBSD 14.4 via `WAVES_PPROF` profile (pre/post)

🤖 Generated with [Claude Code](https://claude.com/claude-code)