### PR TITLE
fix(app): stop tick chain immediately on pause (#28 follow-up)

### DIFF
--- a/internal/app/tick_lifecycle_test.go
+++ b/internal/app/tick_lifecycle_test.go
@@ -94,3 +94,58 @@ func TestCPU_TickChainSurvivesTransitions(t *testing.T) {
 		}
 	})
 }
+
+// Pausing must stop the tick chain immediately (no wasted Update+View while
+// paused). The state-change handler bumps the generation and clears
+// tickRunning, so any in-flight TickMsg from the old generation is dropped.
+func TestCPU_PauseStopsTickImmediately(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		m := newIntegrationTestModel()
+		defer func() {
+			_ = m.PlaybackService.Close()
+			synctest.Wait()
+		}()
+
+		m.PlaybackService.AddTracks(
+			playback.Track{Path: "/a.mp3", Artist: "A", Title: "A", Album: "Alb"},
+		)
+		mock, ok := m.PlaybackService.Player().(*player.Mock)
+		if !ok {
+			t.Fatal("expected mock player")
+		}
+
+		// Start playing -> one chain alive.
+		mock.SetState(player.Playing)
+		mdl, _ := updateModel(t, m, ServiceStateChangedMsg{
+			Previous: int(playback.StateStopped),
+			Current:  int(playback.StatePlaying),
+		})
+		m = mdl
+		if !m.tickRunning {
+			t.Fatal("expected tickRunning=true after play")
+		}
+		staleGen := m.tickGen
+
+		// Playing -> Paused state change. The chain must end immediately, not
+		// on its next tick: tickRunning=false and the generation bumps so any
+		// in-flight TickMsg from the old generation is dropped.
+		mock.SetState(player.Paused)
+		mdl, _ = updateModel(t, m, ServiceStateChangedMsg{
+			Previous: int(playback.StatePlaying),
+			Current:  int(playback.StatePaused),
+		})
+		m = mdl
+		if m.tickRunning {
+			t.Fatal("pause should stop the tick chain immediately (no wasted ticks)")
+		}
+		if m.tickGen == staleGen {
+			t.Fatal("pause should bump tickGen so in-flight ticks are dropped")
+		}
+
+		// A still-in-flight tick from the old generation must not re-arm.
+		_, staleCmd := updateModel(t, m, TickMsg{Gen: staleGen, Time: time.Now()})
+		if got := countTickChains(t, staleCmd); got != 0 {
+			t.Fatalf("stale tick after pause re-armed %d chains, want 0", got)
+		}
+	})
+}

--- a/internal/app/update_playback.go
+++ b/internal/app/update_playback.go
@@ -115,6 +115,11 @@ func (m Model) handleServiceStateChanged(msg ServiceStateChangedMsg) (tea.Model,
 
 	if m.PlaybackService.IsStopped() {
 		m.handlePlaybackStopped()
+	} else if m.PlaybackService.IsPaused() {
+		// End the tick chain immediately so we do not emit another
+		// Update+View while paused (issue #28). Resume reseeds via
+		// ensureTickRunning from handlePlaybackStarted.
+		m.stopTick()
 	}
 
 	return m, m.WatchServiceEvents()


### PR DESCRIPTION
## Summary

Small follow-up to #29. The `Playing -> Paused` transition was falling through `handleServiceStateChanged` without ending the tick chain, so a paused session emitted one final `Update`+`View` before the next tick saw `!IsPlaying()` and called `clearRunning()`. This adds an `IsPaused()` branch that calls `stopTick()` (bumps the generation, clears `tickRunning`), so the chain ends on the pause event itself. Resume reseeds via `ensureTickRunning` as before.

This removes the one-tick residual flagged by the final review of #29 ("the spec's 'no wasted ticks while paused' goal is only approximately met today"). Strictly bounded behavior in #29 was correct already; this just makes it exact.

## Test Plan

- [x] New regression `TestCPU_PauseStopsTickImmediately`: after a `Playing -> Paused` state change, `tickRunning` is `false`, `tickGen` has advanced, and a same-gen in-flight `TickMsg` re-arms zero chains. RED before the one-line fix, GREEN after.
- [x] Existing `TestCPU_TickChainsAccumulatePerTrackChange` and `TestCPU_TickChainSurvivesTransitions` still pass.
- [x] `make check` and full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)