### PR TITLE
fix: support non-ASCII input (Russian, Chinese, etc.) in all text inputs

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,6 +1,9 @@
 package search
 
 import (
+	"unicode"
+	"unicode/utf8"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -147,19 +150,22 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		case "backspace":
 			if m.query != "" {
-				m.query = m.query[:len(m.query)-1]
+				_, size := utf8.DecodeLastRuneInString(m.query)
+				m.query = m.query[:len(m.query)-size]
 				m.cursor = 0
 				m.offset = 0
 				m.updateMatches()
 			}
 
 		default:
-			// Only add printable characters
-			if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-				m.query += msg.String()
-				m.cursor = 0
-				m.offset = 0
-				m.updateMatches()
+			if len(msg.Runes) == 1 {
+				r := msg.Runes[0]
+				if !unicode.IsControl(r) {
+					m.query += string(r)
+					m.cursor = 0
+					m.offset = 0
+					m.updateMatches()
+				}
 			}
 		}
 	}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -158,14 +158,19 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 
 		default:
-			if len(msg.Runes) == 1 {
-				r := msg.Runes[0]
+			// Append all non-control runes. Iterating over Runes (rather than
+			// requiring exactly one) also handles multi-rune paste events.
+			added := false
+			for _, r := range msg.Runes {
 				if !unicode.IsControl(r) {
 					m.query += string(r)
-					m.cursor = 0
-					m.offset = 0
-					m.updateMatches()
+					added = true
 				}
+			}
+			if added {
+				m.cursor = 0
+				m.offset = 0
+				m.updateMatches()
 			}
 		}
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -565,6 +565,59 @@ func TestModel_Update_Backspace(t *testing.T) {
 	}
 }
 
+func TestModel_Update_TypingCyrillic(t *testing.T) {
+	m := New()
+	items := []Item{
+		testItem{filter: "привет", display: "Привет"},
+		testItem{filter: "banana", display: "Banana"},
+	}
+	m.SetItems(items)
+
+	// Type "при" rune by rune.
+	for _, r := range "при" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	if m.query != "при" {
+		t.Errorf("query = %q, want %q", m.query, "при")
+	}
+
+	// Should filter to only the Cyrillic item.
+	if len(m.matches) != 1 {
+		t.Errorf("expected 1 match for %q, got %d", "при", len(m.matches))
+	}
+}
+
+func TestModel_Update_BackspaceCyrillic(t *testing.T) {
+	m := New()
+	m.SetItems([]Item{testItem{filter: "привет", display: "Привет"}})
+
+	for _, r := range "при" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	// Backspace should remove one whole rune, not one byte.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if m.query != "пр" {
+		t.Errorf("after backspace, query = %q, want %q", m.query, "пр")
+	}
+}
+
+func TestModel_Update_PasteMultiRune(t *testing.T) {
+	m := New()
+	m.SetItems([]Item{testItem{filter: "привет", display: "Привет"}})
+
+	// A paste arrives as a single KeyRunes event carrying many runes.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("привет"), Paste: true})
+
+	if m.query != "привет" {
+		t.Errorf("query = %q, want %q", m.query, "привет")
+	}
+	if len(m.matches) != 1 {
+		t.Errorf("expected 1 match after paste, got %d", len(m.matches))
+	}
+}
+
 func TestModel_Update_WindowSize(t *testing.T) {
 	m := New()
 

--- a/internal/ui/albumview/presets_popup.go
+++ b/internal/ui/albumview/presets_popup.go
@@ -179,8 +179,9 @@ func (p *PresetsPopup) handleSaveMode(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 			p.input = p.input[:len(p.input)-size]
 		}
 	default:
-		if len(msg.Runes) == 1 {
-			r := msg.Runes[0]
+		// Append all non-control runes. Iterating over Runes (rather than
+		// requiring exactly one) also handles multi-rune paste events.
+		for _, r := range msg.Runes {
 			if !unicode.IsControl(r) {
 				p.input += string(r)
 			}

--- a/internal/ui/albumview/presets_popup.go
+++ b/internal/ui/albumview/presets_popup.go
@@ -2,6 +2,8 @@ package albumview
 
 import (
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -173,12 +175,15 @@ func (p *PresetsPopup) handleSaveMode(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 		p.input = ""
 	case "backspace":
 		if p.input != "" {
-			p.input = p.input[:len(p.input)-1]
+			_, size := utf8.DecodeLastRuneInString(p.input)
+			p.input = p.input[:len(p.input)-size]
 		}
 	default:
-		// Add printable characters
-		if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-			p.input += msg.String()
+		if len(msg.Runes) == 1 {
+			r := msg.Runes[0]
+			if !unicode.IsControl(r) {
+				p.input += string(r)
+			}
 		}
 	}
 	return p, nil

--- a/internal/ui/albumview/presets_popup_test.go
+++ b/internal/ui/albumview/presets_popup_test.go
@@ -277,6 +277,25 @@ func TestPresetsPopup_BackspaceInSaveMode(t *testing.T) {
 	}
 }
 
+func TestPresetsPopup_TypeCyrillicInSaveMode(t *testing.T) {
+	h := newTestPresetsPopup(nil, albumpreset.Settings{})
+
+	h.SendKey("s") // Enter save mode
+	for _, r := range "альбом" {
+		h.SendKey(string(r))
+	}
+	h.SendEnter()
+
+	act := getPresetsAction(t, h)
+	saved, ok := act.(PresetSaved)
+	if !ok {
+		t.Fatalf("expected PresetSaved, got %T", act)
+	}
+	if saved.Name != "альбом" {
+		t.Errorf("Name = %q, want %q", saved.Name, "альбом")
+	}
+}
+
 // View tests
 
 func TestPresetsPopup_ViewShowsTitle(t *testing.T) {

--- a/internal/ui/export/export_test.go
+++ b/internal/ui/export/export_test.go
@@ -197,6 +197,32 @@ func TestExport_RenameTargetSubmit(t *testing.T) {
 	}
 }
 
+func TestExport_RenameTargetCyrillic(t *testing.T) {
+	targets := sampleTargets()
+	h := newExportPopupWithTargets(targets, sampleVolumes())
+
+	h.SendKey("r") // Enter rename mode
+
+	// Clear existing name "USB Drive" (9 characters)
+	for range 9 {
+		h.SendKey("backspace")
+	}
+
+	for _, r := range "Плеер" {
+		h.SendKey(string(r))
+	}
+	h.SendEnter()
+
+	act := getExportAction(t, h)
+	rename, ok := act.(RenameTarget)
+	if !ok {
+		t.Fatalf("expected RenameTarget, got %T", act)
+	}
+	if rename.NewName != "Плеер" {
+		t.Errorf("NewName = %q, want %q", rename.NewName, "Плеер")
+	}
+}
+
 func TestExport_RenameCancel(t *testing.T) {
 	targets := sampleTargets()
 	h := newExportPopupWithTargets(targets, sampleVolumes())

--- a/internal/ui/export/update.go
+++ b/internal/ui/export/update.go
@@ -397,8 +397,9 @@ func (m *Model) handleRenameTargetKey(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 		}
 
 	default:
-		if len(msg.Runes) == 1 {
-			r := msg.Runes[0]
+		// Append all non-control runes. Iterating over Runes (rather than
+		// requiring exactly one) also handles multi-rune paste events.
+		for _, r := range msg.Runes {
 			if !unicode.IsControl(r) {
 				m.renameInput += string(r)
 			}
@@ -444,8 +445,9 @@ func (m *Model) handleCustomFolderKey(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 		}
 
 	default:
-		if len(msg.Runes) == 1 {
-			r := msg.Runes[0]
+		// Append all non-control runes. Iterating over Runes (rather than
+		// requiring exactly one) also handles multi-rune paste events.
+		for _, r := range msg.Runes {
 			if !unicode.IsControl(r) {
 				m.customFolderInput += string(r)
 			}

--- a/internal/ui/export/update.go
+++ b/internal/ui/export/update.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -390,13 +392,16 @@ func (m *Model) handleRenameTargetKey(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 
 	case "backspace":
 		if m.renameInput != "" {
-			m.renameInput = m.renameInput[:len(m.renameInput)-1]
+			_, size := utf8.DecodeLastRuneInString(m.renameInput)
+			m.renameInput = m.renameInput[:len(m.renameInput)-size]
 		}
 
 	default:
-		// Add printable characters
-		if len(msg.String()) == 1 {
-			m.renameInput += msg.String()
+		if len(msg.Runes) == 1 {
+			r := msg.Runes[0]
+			if !unicode.IsControl(r) {
+				m.renameInput += string(r)
+			}
 		}
 	}
 
@@ -434,13 +439,16 @@ func (m *Model) handleCustomFolderKey(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 
 	case "backspace":
 		if m.customFolderInput != "" {
-			m.customFolderInput = m.customFolderInput[:len(m.customFolderInput)-1]
+			_, size := utf8.DecodeLastRuneInString(m.customFolderInput)
+			m.customFolderInput = m.customFolderInput[:len(m.customFolderInput)-size]
 		}
 
 	default:
-		// Add printable characters
-		if len(msg.String()) == 1 {
-			m.customFolderInput += msg.String()
+		if len(msg.Runes) == 1 {
+			r := msg.Runes[0]
+			if !unicode.IsControl(r) {
+				m.customFolderInput += string(r)
+			}
 		}
 	}
 

--- a/internal/ui/librarysources/librarysources.go
+++ b/internal/ui/librarysources/librarysources.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -185,12 +187,16 @@ func (m *Model) updateAdd(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 
 	case "backspace":
 		if m.inputText != "" {
-			m.inputText = m.inputText[:len(m.inputText)-1]
+			_, size := utf8.DecodeLastRuneInString(m.inputText)
+			m.inputText = m.inputText[:len(m.inputText)-size]
 		}
 
 	default:
-		if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-			m.inputText += msg.String()
+		if len(msg.Runes) == 1 {
+			r := msg.Runes[0]
+			if !unicode.IsControl(r) {
+				m.inputText += string(r)
+			}
 		}
 	}
 

--- a/internal/ui/librarysources/librarysources.go
+++ b/internal/ui/librarysources/librarysources.go
@@ -192,8 +192,9 @@ func (m *Model) updateAdd(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 		}
 
 	default:
-		if len(msg.Runes) == 1 {
-			r := msg.Runes[0]
+		// Append all non-control runes. Iterating over Runes (rather than
+		// requiring exactly one) also handles multi-rune paste events.
+		for _, r := range msg.Runes {
 			if !unicode.IsControl(r) {
 				m.inputText += string(r)
 			}

--- a/internal/ui/librarysources/librarysources_test.go
+++ b/internal/ui/librarysources/librarysources_test.go
@@ -229,6 +229,19 @@ func TestAddMode_Backspace(t *testing.T) {
 	}
 }
 
+func TestAddMode_TypeCyrillic(t *testing.T) {
+	h := newTestPopup(nil)
+
+	h.SendKey("a") // Enter add mode
+	for _, r := range "музыка" {
+		h.SendKey(string(r))
+	}
+
+	if err := h.AssertViewContains("> музыка"); err != "" {
+		t.Error(err)
+	}
+}
+
 func TestAddMode_TildeExpansion(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/ui/textinput/textinput.go
+++ b/internal/ui/textinput/textinput.go
@@ -2,6 +2,9 @@
 package textinput
 
 import (
+	"unicode"
+	"unicode/utf8"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -79,13 +82,16 @@ func (m *Model) Update(msg tea.Msg) (popup.Popup, tea.Cmd) {
 
 		case "backspace":
 			if m.text != "" {
-				m.text = m.text[:len(m.text)-1]
+				_, size := utf8.DecodeLastRuneInString(m.text)
+				m.text = m.text[:len(m.text)-size]
 			}
 
 		default:
-			// Only add printable characters
-			if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-				m.text += msg.String()
+			if len(msg.Runes) == 1 {
+				r := msg.Runes[0]
+				if !unicode.IsControl(r) {
+					m.text += string(r)
+				}
 			}
 		}
 	}

--- a/internal/ui/textinput/textinput.go
+++ b/internal/ui/textinput/textinput.go
@@ -87,8 +87,9 @@ func (m *Model) Update(msg tea.Msg) (popup.Popup, tea.Cmd) {
 			}
 
 		default:
-			if len(msg.Runes) == 1 {
-				r := msg.Runes[0]
+			// Append all non-control runes. Iterating over Runes (rather than
+			// requiring exactly one) also handles multi-rune paste events.
+			for _, r := range msg.Runes {
 				if !unicode.IsControl(r) {
 					m.text += string(r)
 				}

--- a/internal/ui/textinput/textinput_test.go
+++ b/internal/ui/textinput/textinput_test.go
@@ -204,6 +204,50 @@ func TestTextInput_Reset(t *testing.T) {
 	}
 }
 
+// Unicode / multibyte input tests
+
+func TestTextInput_TypeCyrillic(t *testing.T) {
+	h := newTestInput("Search", "", nil)
+
+	// "привет" typed character by character.
+	for _, r := range "привет" {
+		h.SendKey(string(r))
+	}
+	h.SendEnter()
+
+	result := getResult(t, h)
+	if result.Text != "привет" {
+		t.Errorf("Text = %q, want %q", result.Text, "привет")
+	}
+}
+
+func TestTextInput_BackspaceMultibyte(t *testing.T) {
+	h := newTestInput("Search", "привет", nil)
+
+	// Two backspaces should remove two whole runes, not two bytes.
+	h.SendSpecialKey(tea.KeyBackspace)
+	h.SendSpecialKey(tea.KeyBackspace)
+	h.SendEnter()
+
+	result := getResult(t, h)
+	if result.Text != "прив" {
+		t.Errorf("Text = %q, want %q", result.Text, "прив")
+	}
+}
+
+func TestTextInput_PasteMultiRune(t *testing.T) {
+	h := newTestInput("Search", "", nil)
+
+	// A paste arrives as a single KeyRunes event carrying many runes.
+	h.SendMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("привет"), Paste: true})
+	h.SendEnter()
+
+	result := getResult(t, h)
+	if result.Text != "привет" {
+		t.Errorf("Text = %q, want %q", result.Text, "привет")
+	}
+}
+
 // Non-printable characters test
 
 func TestTextInput_IgnoresControlCharacters(t *testing.T) {


### PR DESCRIPTION
Replace byte-length checks (len(msg.String()) == 1) with rune-based checks (len(msg.Runes) == 1 && !unicode.IsControl(r)) across all text input handlers. Also fix backspace to use
utf8.DecodeLastRuneInString instead of byte slicing.

Affected components:
- internal/ui/textinput (generic text input popup)
- internal/search (incremental search with '/' key)
- internal/ui/albumview/presets_popup (album presets)
- internal/ui/librarysources (library source paths)
- internal/ui/export (export rename and custom folder inputs)

all work do opencode big pickle (free) for like 10 min