### PR TITLE
fix(ui): accept multibyte UTF-8 input in text fields (#32)

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -147,16 +147,23 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		case "backspace":
 			if m.query != "" {
-				m.query = m.query[:len(m.query)-1]
+				r := []rune(m.query)
+				m.query = string(r[:len(r)-1])
 				m.cursor = 0
 				m.offset = 0
 				m.updateMatches()
 			}
 
 		default:
-			// Only add printable characters
-			if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-				m.query += msg.String()
+			// Append printable runes. Iterating over Runes (rather than
+			// inspecting String()) keeps multibyte UTF-8 input working, e.g.
+			// Cyrillic or CJK characters (issue #32).
+			if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
+				for _, r := range msg.Runes {
+					if r >= 32 {
+						m.query += string(r)
+					}
+				}
 				m.cursor = 0
 				m.offset = 0
 				m.updateMatches()

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -565,6 +565,44 @@ func TestModel_Update_Backspace(t *testing.T) {
 	}
 }
 
+func TestModel_Update_TypingCyrillic(t *testing.T) {
+	m := New()
+	items := []Item{
+		testItem{filter: "привет", display: "Привет"},
+		testItem{filter: "banana", display: "Banana"},
+	}
+	m.SetItems(items)
+
+	// Type "при" rune by rune.
+	for _, r := range "при" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	if m.query != "при" {
+		t.Errorf("query = %q, want %q", m.query, "при")
+	}
+
+	// Should filter to only the Cyrillic item.
+	if len(m.matches) != 1 {
+		t.Errorf("expected 1 match for %q, got %d", "при", len(m.matches))
+	}
+}
+
+func TestModel_Update_BackspaceCyrillic(t *testing.T) {
+	m := New()
+	m.SetItems([]Item{testItem{filter: "привет", display: "Привет"}})
+
+	for _, r := range "при" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	// Backspace should remove one whole rune, not one byte.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if m.query != "пр" {
+		t.Errorf("after backspace, query = %q, want %q", m.query, "пр")
+	}
+}
+
 func TestModel_Update_WindowSize(t *testing.T) {
 	m := New()
 

--- a/internal/ui/albumview/presets_popup.go
+++ b/internal/ui/albumview/presets_popup.go
@@ -173,12 +173,17 @@ func (p *PresetsPopup) handleSaveMode(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 		p.input = ""
 	case "backspace":
 		if p.input != "" {
-			p.input = p.input[:len(p.input)-1]
+			r := []rune(p.input)
+			p.input = string(r[:len(r)-1])
 		}
 	default:
-		// Add printable characters
-		if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-			p.input += msg.String()
+		// Append printable runes (handles multibyte UTF-8, e.g. Cyrillic — issue #32).
+		if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
+			for _, r := range msg.Runes {
+				if r >= 32 {
+					p.input += string(r)
+				}
+			}
 		}
 	}
 	return p, nil

--- a/internal/ui/albumview/presets_popup_test.go
+++ b/internal/ui/albumview/presets_popup_test.go
@@ -277,6 +277,25 @@ func TestPresetsPopup_BackspaceInSaveMode(t *testing.T) {
 	}
 }
 
+func TestPresetsPopup_TypeCyrillicInSaveMode(t *testing.T) {
+	h := newTestPresetsPopup(nil, albumpreset.Settings{})
+
+	h.SendKey("s") // Enter save mode
+	for _, r := range "альбом" {
+		h.SendKey(string(r))
+	}
+	h.SendEnter()
+
+	act := getPresetsAction(t, h)
+	saved, ok := act.(PresetSaved)
+	if !ok {
+		t.Fatalf("expected PresetSaved, got %T", act)
+	}
+	if saved.Name != "альбом" {
+		t.Errorf("Name = %q, want %q", saved.Name, "альбом")
+	}
+}
+
 // View tests
 
 func TestPresetsPopup_ViewShowsTitle(t *testing.T) {

--- a/internal/ui/export/export_test.go
+++ b/internal/ui/export/export_test.go
@@ -197,6 +197,32 @@ func TestExport_RenameTargetSubmit(t *testing.T) {
 	}
 }
 
+func TestExport_RenameTargetCyrillic(t *testing.T) {
+	targets := sampleTargets()
+	h := newExportPopupWithTargets(targets, sampleVolumes())
+
+	h.SendKey("r") // Enter rename mode
+
+	// Clear existing name "USB Drive" (9 characters)
+	for range 9 {
+		h.SendKey("backspace")
+	}
+
+	for _, r := range "Плеер" {
+		h.SendKey(string(r))
+	}
+	h.SendEnter()
+
+	act := getExportAction(t, h)
+	rename, ok := act.(RenameTarget)
+	if !ok {
+		t.Fatalf("expected RenameTarget, got %T", act)
+	}
+	if rename.NewName != "Плеер" {
+		t.Errorf("NewName = %q, want %q", rename.NewName, "Плеер")
+	}
+}
+
 func TestExport_RenameCancel(t *testing.T) {
 	targets := sampleTargets()
 	h := newExportPopupWithTargets(targets, sampleVolumes())

--- a/internal/ui/export/update.go
+++ b/internal/ui/export/update.go
@@ -390,13 +390,18 @@ func (m *Model) handleRenameTargetKey(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 
 	case "backspace":
 		if m.renameInput != "" {
-			m.renameInput = m.renameInput[:len(m.renameInput)-1]
+			r := []rune(m.renameInput)
+			m.renameInput = string(r[:len(r)-1])
 		}
 
 	default:
-		// Add printable characters
-		if len(msg.String()) == 1 {
-			m.renameInput += msg.String()
+		// Append printable runes (handles multibyte UTF-8, e.g. Cyrillic — issue #32).
+		if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
+			for _, r := range msg.Runes {
+				if r >= 32 {
+					m.renameInput += string(r)
+				}
+			}
 		}
 	}
 
@@ -434,13 +439,18 @@ func (m *Model) handleCustomFolderKey(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 
 	case "backspace":
 		if m.customFolderInput != "" {
-			m.customFolderInput = m.customFolderInput[:len(m.customFolderInput)-1]
+			r := []rune(m.customFolderInput)
+			m.customFolderInput = string(r[:len(r)-1])
 		}
 
 	default:
-		// Add printable characters
-		if len(msg.String()) == 1 {
-			m.customFolderInput += msg.String()
+		// Append printable runes (handles multibyte UTF-8, e.g. Cyrillic — issue #32).
+		if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
+			for _, r := range msg.Runes {
+				if r >= 32 {
+					m.customFolderInput += string(r)
+				}
+			}
 		}
 	}
 

--- a/internal/ui/librarysources/librarysources.go
+++ b/internal/ui/librarysources/librarysources.go
@@ -185,12 +185,18 @@ func (m *Model) updateAdd(msg tea.KeyMsg) (popup.Popup, tea.Cmd) {
 
 	case "backspace":
 		if m.inputText != "" {
-			m.inputText = m.inputText[:len(m.inputText)-1]
+			r := []rune(m.inputText)
+			m.inputText = string(r[:len(r)-1])
 		}
 
 	default:
-		if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-			m.inputText += msg.String()
+		// Append printable runes (handles multibyte UTF-8, e.g. Cyrillic — issue #32).
+		if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
+			for _, r := range msg.Runes {
+				if r >= 32 {
+					m.inputText += string(r)
+				}
+			}
 		}
 	}
 

--- a/internal/ui/librarysources/librarysources_test.go
+++ b/internal/ui/librarysources/librarysources_test.go
@@ -229,6 +229,19 @@ func TestAddMode_Backspace(t *testing.T) {
 	}
 }
 
+func TestAddMode_TypeCyrillic(t *testing.T) {
+	h := newTestPopup(nil)
+
+	h.SendKey("a") // Enter add mode
+	for _, r := range "музыка" {
+		h.SendKey(string(r))
+	}
+
+	if err := h.AssertViewContains("> музыка"); err != "" {
+		t.Error(err)
+	}
+}
+
 func TestAddMode_TildeExpansion(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/ui/textinput/textinput.go
+++ b/internal/ui/textinput/textinput.go
@@ -79,13 +79,20 @@ func (m *Model) Update(msg tea.Msg) (popup.Popup, tea.Cmd) {
 
 		case "backspace":
 			if m.text != "" {
-				m.text = m.text[:len(m.text)-1]
+				r := []rune(m.text)
+				m.text = string(r[:len(r)-1])
 			}
 
 		default:
-			// Only add printable characters
-			if len(msg.String()) == 1 && msg.String()[0] >= 32 {
-				m.text += msg.String()
+			// Append printable runes. Iterating over Runes (rather than
+			// inspecting String()) keeps multibyte UTF-8 input working, e.g.
+			// Cyrillic or CJK characters (issue #32).
+			if msg.Type == tea.KeyRunes || msg.Type == tea.KeySpace {
+				for _, r := range msg.Runes {
+					if r >= 32 {
+						m.text += string(r)
+					}
+				}
 			}
 		}
 	}

--- a/internal/ui/textinput/textinput_test.go
+++ b/internal/ui/textinput/textinput_test.go
@@ -204,6 +204,37 @@ func TestTextInput_Reset(t *testing.T) {
 	}
 }
 
+// Unicode / multibyte input tests
+
+func TestTextInput_TypeCyrillic(t *testing.T) {
+	h := newTestInput("Search", "", nil)
+
+	// "привет" typed character by character.
+	for _, r := range "привет" {
+		h.SendKey(string(r))
+	}
+	h.SendEnter()
+
+	result := getResult(t, h)
+	if result.Text != "привет" {
+		t.Errorf("Text = %q, want %q", result.Text, "привет")
+	}
+}
+
+func TestTextInput_BackspaceMultibyte(t *testing.T) {
+	h := newTestInput("Search", "привет", nil)
+
+	// Two backspaces should remove two whole runes, not two bytes.
+	h.SendSpecialKey(tea.KeyBackspace)
+	h.SendSpecialKey(tea.KeyBackspace)
+	h.SendEnter()
+
+	result := getResult(t, h)
+	if result.Text != "прив" {
+		t.Errorf("Text = %q, want %q", result.Text, "прив")
+	}
+}
+
 // Non-printable characters test
 
 func TestTextInput_IgnoresControlCharacters(t *testing.T) {


### PR DESCRIPTION
## Problem

Closes #32. Cyrillic (and any non-Latin / multibyte UTF-8) input was silently dropped in the search popup. The terminal displays Cyrillic fine; only input was broken.

## Root cause

Custom text-input handlers gated character input on `len(msg.String()) == 1`, which only admits single-byte ASCII. For a `KeyRunes` event, `msg.String()` returns `string(msg.Runes)`, so a Cyrillic character (2 bytes in UTF-8) failed the check and was dropped. Backspace had the matching flaw: `text[:len(text)-1]` trims one **byte**, corrupting a multibyte rune.

## Fix

Append `msg.Runes` directly (handling `KeyRunes` and `KeySpace`) and backspace by rune via `[]rune(...)`.

Applied to every custom input handler with this bug:

- `internal/search/search.go` — the reported search popup
- `internal/ui/textinput/textinput.go` — generic text input (playlist names, etc.)
- `internal/ui/albumview/presets_popup.go` — preset name entry
- `internal/ui/librarysources/librarysources.go` — library source path entry
- `internal/ui/export/update.go` — target rename + custom folder (these also gained the `>= 32` control-char guard the others already had)

The download/retag screens use upstream `bubbles/textinput`, which already handles UTF-8, so they were left untouched.

## Tests

TDD red→green for each package. Added Cyrillic typing + multibyte-backspace regression tests; confirmed each fails before the fix and passes after. `make check` (fmt + lint + full suite) passes.

## Related work

Issue #32 also requested a "queue all from library / shuffle entire library" feature. That's an unrelated enhancement, out of scope for this fix, and is tracked separately in #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)