### PR TITLE
perf(player): buffer file reads to stop syscall storm on network mounts

### DIFF
--- a/internal/player/bufseek.go
+++ b/internal/player/bufseek.go
@@ -1,0 +1,84 @@
+package player
+
+import (
+	"errors"
+	"io"
+	"os"
+)
+
+// bufBlock is the read-ahead block size. Decoders pull frame-sized reads
+// (~265 bytes on MP3); unbuffered that is one syscall — one network round
+// trip on a remote mount — per frame. See issue #36.
+const bufBlock = 256 * 1024
+
+type sourceFile interface {
+	io.ReaderAt
+	io.Closer
+	Stat() (os.FileInfo, error)
+}
+
+// bufferedFile is a seekable read-ahead buffer over a file: it caches one
+// aligned block, so the decoders' small reads and short backward seeks are
+// served from memory. bufio.Reader can't be used, it loses Seek and re-reads
+// the whole file on every backward seek.
+type bufferedFile struct {
+	f     sourceFile
+	buf   []byte
+	start int64 // file offset of buf[0]
+	n     int   // valid bytes in buf
+	pos   int64 // logical read offset
+	size  int64
+}
+
+func newBufferedFile(f sourceFile) (*bufferedFile, error) {
+	st, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &bufferedFile{f: f, buf: make([]byte, bufBlock), size: st.Size()}, nil
+}
+
+func (b *bufferedFile) Read(p []byte) (int, error) {
+	if b.pos >= b.size {
+		return 0, io.EOF
+	}
+	if b.pos < b.start || b.pos >= b.start+int64(b.n) {
+		if err := b.fill(b.pos); err != nil {
+			return 0, err
+		}
+	}
+	n := copy(p, b.buf[b.pos-b.start:b.n])
+	b.pos += int64(n)
+	return n, nil
+}
+
+// fill loads the aligned block containing off.
+func (b *bufferedFile) fill(off int64) error {
+	start := off - off%bufBlock
+	n, err := b.f.ReadAt(b.buf, start)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	b.start, b.n = start, n
+	if n == 0 {
+		return io.EOF
+	}
+	return nil
+}
+
+func (b *bufferedFile) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekCurrent:
+		offset += b.pos
+	case io.SeekEnd:
+		offset += b.size
+	}
+	if offset < 0 {
+		return 0, os.ErrInvalid
+	}
+	b.pos = offset
+	return offset, nil
+}
+
+func (b *bufferedFile) Close() error { return b.f.Close() }

--- a/internal/player/bufseek_test.go
+++ b/internal/player/bufseek_test.go
@@ -1,0 +1,140 @@
+package player
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// countingFile counts the reads that reach the real file.
+type countingFile struct {
+	*os.File
+	reads int
+	bytes int64
+}
+
+func (c *countingFile) ReadAt(p []byte, off int64) (int, error) {
+	c.reads++
+	n, err := c.File.ReadAt(p, off)
+	c.bytes += int64(n)
+	return n, err
+}
+
+func openCounted(t *testing.T, path string) (*bufferedFile, *countingFile) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &countingFile{File: f}
+	b, err := newBufferedFile(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { b.Close() })
+	return b, c
+}
+
+func TestBufferedFileCollapsesReads(t *testing.T) {
+	// 1 MB read in 265-byte chunks (the MP3 decoder's pattern): unbuffered
+	// that is ~4000 syscalls.
+	path := filepath.Join(t.TempDir(), "data")
+	if err := os.WriteFile(path, make([]byte, 1<<20), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	b, c := openCounted(t, path)
+
+	chunk := make([]byte, 265)
+	for {
+		if _, err := b.Read(chunk); err != nil {
+			break
+		}
+	}
+	if c.reads > 5 {
+		t.Errorf("reading 1 MB in 265-byte chunks hit the file %d times, want <= 5", c.reads)
+	}
+}
+
+func TestBufferedFileShortBackwardSeekIsFree(t *testing.T) {
+	// go-mp3 reads a frame then seeks back a few bytes, thousands of times.
+	// That must not re-read the file.
+	path := filepath.Join(t.TempDir(), "data")
+	if err := os.WriteFile(path, make([]byte, 1<<20), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	b, c := openCounted(t, path)
+
+	chunk := make([]byte, 265)
+	for range 2000 {
+		if _, err := b.Read(chunk); err != nil {
+			break
+		}
+		if _, err := b.Seek(-4, io.SeekCurrent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if c.bytes > 2<<20 {
+		t.Errorf("read %d bytes off a 1 MB file, want no re-reading", c.bytes)
+	}
+}
+
+func TestBufferedFileSeek(t *testing.T) {
+	src := "testdata/vorbis_44100_stereo.ogg"
+	want, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := openCounted(t, src)
+
+	got := make([]byte, 16)
+	for _, off := range []int64{0, 100, 4096, 50, int64(len(want)) - 16} {
+		if _, err := b.Seek(off, io.SeekStart); err != nil {
+			t.Fatalf("seek %d: %v", off, err)
+		}
+		if _, err := io.ReadFull(b, got); err != nil {
+			t.Fatalf("read at %d: %v", off, err)
+		}
+		if !bytes.Equal(got, want[off:off+16]) {
+			t.Errorf("wrong bytes at offset %d", off)
+		}
+	}
+
+	end, err := b.Seek(0, io.SeekEnd)
+	if err != nil || end != int64(len(want)) {
+		t.Fatalf("SeekEnd = %d, %v; want %d", end, err, len(want))
+	}
+	if _, err := b.Read(got); !errors.Is(err, io.EOF) {
+		t.Errorf("read at EOF = %v, want io.EOF", err)
+	}
+	if _, err := b.Seek(-16, io.SeekCurrent); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(b, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want[len(want)-16:]) {
+		t.Error("wrong bytes after SeekCurrent")
+	}
+}
+
+func TestBufferedFileDecodesOgg(t *testing.T) {
+	b, c := openCounted(t, "testdata/vorbis_44100_stereo.ogg")
+	src, _, err := decodeOgg(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+
+	buf := make([][2]float64, 512)
+	for {
+		if n, ok := src.Stream(buf); !ok || n == 0 {
+			break
+		}
+	}
+	if c.reads > 2 {
+		t.Errorf("decoding a 7.6 KB file hit the file %d times, want <= 2", c.reads)
+	}
+}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -1,7 +1,6 @@
 package player
 
 import (
-	"os"
 	"sync"
 	"time"
 
@@ -32,7 +31,7 @@ const (
 
 // trackState bundles all resources for a single track.
 type trackState struct {
-	file      *os.File
+	file      *bufferedFile
 	streamer  beep.StreamSeekCloser
 	resampled beep.Streamer // Resampled to speaker rate (may equal streamer)
 	format    beep.Format

--- a/internal/player/stream.go
+++ b/internal/player/stream.go
@@ -23,7 +23,13 @@ func (p *Player) openTrack(path string) (*trackState, error) {
 		return nil, fmt.Errorf("unsupported format: %s", ext)
 	}
 
-	f, err := os.Open(path)
+	osFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	// Decoders pull frame-sized reads; unbuffered that is one syscall (one
+	// network round trip) per frame. See issue #36.
+	f, err := newBufferedFile(osFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #36.

## What was happening

`openTrack` handed a raw `*os.File` to the decoders, which pull frame-sized
reads (~263 bytes on MP3). Each one is a syscall; on a network filesystem with
a cold cache each one is kernel filesystem work. Measured on one 13 MB MP3 over
the reporter's CIFS mount:

| | reads | seeks | I/O stall | wall |
|---|---|---|---|---|
| before | 81 957 | 20 429 | 6 930 ms | 9.6 s |
| after | 104 | 0 | 3 703 ms | 5.9 s |

(`I/O stall` = delta of `full` total in `/proc/pressure/io` over the decode.)
That is the round-trip count the issue points at, not throughput — hence the
symptom disappearing on replay, once the file is in the page cache.

## The fix

`internal/player/bufseek.go` — `bufferedFile` caches one 256 KB aligned block
over `ReadAt`.

`bufio.Reader` is not usable here: it loses `Seek`, and measured, wrapping it
made every backward seek drop the buffer and re-read from disk — 17.3 MB of
reads for an 8.6 MB file. An aligned block served through `ReadAt` makes short
backward seeks free and costs zero seek syscalls.

## Verified on all four formats

Reads reaching the file, on real library files, with an identical decoded
sample count before and after:

| format | before | after | file |
|---|---|---|---|
| MP3 | 81 957 | 104 | 13 MB |
| FLAC | 5 105 | 81 | 20 MB |
| M4A | 10 627 | 66 | 8.5 MB |
| Ogg | 12 | 1 | 7.6 KB |

Regression tests in `bufseek_test.go` cover read collapsing, short backward
seeks not re-reading, seek correctness against the file bytes, and an
end-to-end Ogg decode read count.

## Not in this PR

The residual 3.7 s stall is `go-mp3` scanning every frame at open time and then
re-reading the whole file to decode it (2× the bytes). Filed as
llehouerou/go-mp3#1.

`openTrack` still opens the file a second time via `tags.Read(path)` (and a
third via `IsOpusCodec` for `.ogg`) — that is 2-3 opens, not 20 000, worth
revisiting only if `deferredclose` activity persists after this.