### PR TITLE
fix(player): end the track when seeking past its end

### DIFF
--- a/internal/player/controls.go
+++ b/internal/player/controls.go
@@ -137,9 +137,12 @@ func (p *Player) doSeek(delta time.Duration) {
 	maxPos := streamer.Len()
 	newPos := currentPos + p.current.format.SampleRate.N(delta)
 
-	// If seeking past the end, signal track finished
+	// Seeking past the end ends the track. Stop first: a consumer that sees the
+	// player still Playing takes it for a gapless transition the player already
+	// made, and skips the next track (issue #38). This runs before the
+	// speaker.Lock() below, so it cannot deadlock the way it did before 4c008e8.
 	if newPos >= maxPos {
-		// Signal finish via the channel (non-blocking)
+		p.Stop()
 		select {
 		case p.finishedCh <- struct{}{}:
 		default:

--- a/internal/player/seek_end_test.go
+++ b/internal/player/seek_end_test.go
@@ -1,0 +1,69 @@
+package player
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gopxl/beep/v2"
+	"github.com/gopxl/beep/v2/effects"
+	"github.com/stretchr/testify/assert"
+)
+
+// seekableMock is a mockStreamer with a seekable position, standing in for a
+// decoded track.
+type seekableMock struct {
+	mockStreamer
+}
+
+func (s *seekableMock) Len() int { return s.samples }
+
+func (s *seekableMock) Position() int { return s.produced }
+
+func (s *seekableMock) Seek(p int) error {
+	s.produced = p
+	return nil
+}
+
+func (s *seekableMock) Close() error { return nil }
+
+func playingPlayer(streamer beep.StreamSeekCloser) *Player {
+	p := New()
+	p.current = &trackState{
+		streamer:  streamer,
+		resampled: streamer,
+		format:    beep.Format{SampleRate: 44100, NumChannels: 2, Precision: 2},
+	}
+	p.volume = &effects.Volume{Streamer: streamer}
+	p.state = Playing
+	return p
+}
+
+// Seeking past the end must end the track once: one finished signal, and a
+// player that is no longer playing the old track. Issue #38: it used to signal
+// while leaving the track playing, so the consumer advanced the queue, skipped
+// the next track, and advanced again at the real end.
+func TestSeekPastEndEndsTheTrack(t *testing.T) {
+	streamer := &seekableMock{mockStreamer{samples: 44100}} // 1 second
+	p := playingPlayer(streamer)
+
+	p.doSeek(10 * time.Second)
+
+	select {
+	case <-p.FinishedChan():
+	default:
+		t.Fatal("no finished signal after seeking past the end")
+	}
+
+	assert.NotEqual(t, Playing, p.State(),
+		"player still reports Playing, so the consumer treats it as a gapless switch and skips the next track")
+
+	// The old track must not produce audio any more, and must not fire a
+	// second finished signal later.
+	assert.Nil(t, p.current, "current track still attached after seeking past the end")
+
+	select {
+	case <-p.FinishedChan():
+		t.Fatal("second finished signal: the queue would advance twice")
+	default:
+	}
+}


### PR DESCRIPTION
Fixes #38.

## The bug

Seeking forward past the end of a track: the UI announced the next track, the
current one kept playing to its real end, and playback then jumped to N+2 —
N+1 never played.

`doSeek` signalled `finishedCh` but never touched the streamer:

```go
if newPos >= maxPos {
    select {
    case p.finishedCh <- struct{}{}:
    default:
    }
    return          // track N is still playing
}
```

`serviceImpl.handleTrackFinished` advances the queue, then checks
`s.player.State() == player.Playing` to detect a gapless transition the player
already made. With track N still playing that check is true, so the service
moved the index to N+1 and started nothing. At the real end of N a second
signal fired, the queue advanced again, and N+2 played.

## The fix

Stop the player before signalling, so the state the consumer reads is true.

This is what the branch did before 4c008e8, which removed it because `Stop()`
deadlocked against a held `speaker.Lock()`. That is no longer the case: this
branch returns before the lock is taken.

## Test

`internal/player/seek_end_test.go` drives `doSeek` past the end on a stub
streamer and asserts exactly one finished signal, a player no longer reporting
`Playing`, and no track left attached. It fails on `main` on the first two
assertions.