### PR TITLE
chore(deps): go-mp3 v1.3.0, which reads each file once

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ pkgs.buildGoModule {
 
   doCheck = true;
 
-  vendorHash = "sha256-lps0OdY8KoILJh/roY78iC+bYHPeENioQoIsL6v/N0A=";
+  vendorHash = "sha256-3NeN6fMeSsEoROqvWtavHWA5SPpPmZ/utqNJYAtqmYg=";
 
   buildInputs = with pkgs; [
     alsa-lib

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/llehouerou/alac v0.1.0
 	github.com/llehouerou/go-faad2 v0.3.0
 	github.com/llehouerou/go-m4a v0.1.0
-	github.com/llehouerou/go-mp3 v1.2.0
+	github.com/llehouerou/go-mp3 v1.3.0
 	github.com/llehouerou/go-mp4tag v0.1.0
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-runewidth v0.0.19

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/llehouerou/go-faad2 v0.3.0 h1:cCj1lJd3VfnTSDSnKMjNFFEYsp5KsHmQxCLxSY4
 github.com/llehouerou/go-faad2 v0.3.0/go.mod h1:Q3GuJjnorKbt43ea1lqg2cc2tlX/k5C5VWyTuAkzwws=
 github.com/llehouerou/go-m4a v0.1.0 h1:YMQDetIvXZpgRe787frDnJMTbaYWEin6/A/gZzmfMsc=
 github.com/llehouerou/go-m4a v0.1.0/go.mod h1:MyOMdc5eh6cozxm6AIOmj56NwYVkJ2dhE2GEta1lOu0=
-github.com/llehouerou/go-mp3 v1.2.0 h1:2WN/bjCGhfPZAQbSSF35DxNKS/+HPnJ76TakA7Kyscs=
-github.com/llehouerou/go-mp3 v1.2.0/go.mod h1:/Rl7E/VQpWTQDTJgr69iYVSkS1BZEh4X/ABV1XvIpHA=
+github.com/llehouerou/go-mp3 v1.3.0 h1:w7tpKzsnLF93wFpnHbz6DCN6/CwAl5JV+ZZ23SIQ4Ns=
+github.com/llehouerou/go-mp3 v1.3.0/go.mod h1:/Rl7E/VQpWTQDTJgr69iYVSkS1BZEh4X/ABV1XvIpHA=
 github.com/llehouerou/go-mp4tag v0.1.0 h1:b0oLLG+mqKbNVzmjX2x4b3xsfoUbqTWqVh9CJXGdhhk=
 github.com/llehouerou/go-mp4tag v0.1.0/go.mod h1:jmppRy1odyGuYQOI3EACW4lbkjRVM3DUnkRtN9VtTDA=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=


### PR DESCRIPTION
Upstream follow-up to #36 / #37.

go-mp3 v1.3.0 (llehouerou/go-mp3#1) stops scanning every frame at open time —
it derives the length from the Xing header — and buffers reads inside its
source.

Measured on the same 21.4 MB MP3 over a CIFS mount, decoding the whole track,
identical sample count in all four runs:

| | reads | seeks | bytes read |
|---|---|---|---|
| v1.2.0, raw `*os.File` | 81 957 | 20 429 | one pass, via 20k seeks |
| v1.2.0, `bufferedFile` | 104 | 0 | **two passes** |
| v1.3.0, raw `*os.File` | 330 | 2 | one pass |
| v1.3.0, `bufferedFile` | **82** | **0** | **one pass** |

The double read the merged buffering could not avoid is gone: waves now moves
exactly the bytes of the file, in 256 KB blocks, with no seek syscall.

`bufferedFile` stays useful — it is what takes MP3 from 330 to 82 reads, and it
is still the only thing buffering the FLAC (5 105 -> 81), M4A (10 627 -> 66) and
Ogg paths.

`default.nix` vendorHash updated by the pre-commit hook.