### PR TITLE
chore(deps): go-mp3 v1.4.0, 2.4x faster decoding

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ pkgs.buildGoModule {
 
   doCheck = true;
 
-  vendorHash = "sha256-3NeN6fMeSsEoROqvWtavHWA5SPpPmZ/utqNJYAtqmYg=";
+  vendorHash = "sha256-c/U6/94GS+R+CY+fMKAzi2PykQd5uRVKsZYg49M9BO4=";
 
   buildInputs = with pkgs; [
     alsa-lib

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/llehouerou/alac v0.1.0
 	github.com/llehouerou/go-faad2 v0.3.0
 	github.com/llehouerou/go-m4a v0.1.0
-	github.com/llehouerou/go-mp3 v1.3.0
+	github.com/llehouerou/go-mp3 v1.4.0
 	github.com/llehouerou/go-mp4tag v0.1.0
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-runewidth v0.0.19

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/llehouerou/go-faad2 v0.3.0 h1:cCj1lJd3VfnTSDSnKMjNFFEYsp5KsHmQxCLxSY4
 github.com/llehouerou/go-faad2 v0.3.0/go.mod h1:Q3GuJjnorKbt43ea1lqg2cc2tlX/k5C5VWyTuAkzwws=
 github.com/llehouerou/go-m4a v0.1.0 h1:YMQDetIvXZpgRe787frDnJMTbaYWEin6/A/gZzmfMsc=
 github.com/llehouerou/go-m4a v0.1.0/go.mod h1:MyOMdc5eh6cozxm6AIOmj56NwYVkJ2dhE2GEta1lOu0=
-github.com/llehouerou/go-mp3 v1.3.0 h1:w7tpKzsnLF93wFpnHbz6DCN6/CwAl5JV+ZZ23SIQ4Ns=
-github.com/llehouerou/go-mp3 v1.3.0/go.mod h1:/Rl7E/VQpWTQDTJgr69iYVSkS1BZEh4X/ABV1XvIpHA=
+github.com/llehouerou/go-mp3 v1.4.0 h1:rJWa/3jEbwU1FYlZrFjUTbYLUz+lIgkNJqkt9FsqeMQ=
+github.com/llehouerou/go-mp3 v1.4.0/go.mod h1:/Rl7E/VQpWTQDTJgr69iYVSkS1BZEh4X/ABV1XvIpHA=
 github.com/llehouerou/go-mp4tag v0.1.0 h1:b0oLLG+mqKbNVzmjX2x4b3xsfoUbqTWqVh9CJXGdhhk=
 github.com/llehouerou/go-mp4tag v0.1.0/go.mod h1:jmppRy1odyGuYQOI3EACW4lbkjRVM3DUnkRtN9VtTDA=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=


### PR DESCRIPTION
Upstream perf work (llehouerou/go-mp3#6 and the DCT/IMDCT PRs) released as v1.4.0.

Measured in waves, whole-track decode through `decodeGoMP3` on a 21.4 MB / 8m56
MP3 in page cache, 3 runs of 5 iterations each:

| | ns/op | throughput |
|---|---|---|
| v1.3.0 | 8 553 / 8 518 / 8 555 ms | 2.51 MB/s |
| v1.4.0 | 3 537 / 3 504 / 3 506 ms | **6.12 MB/s** |

Under 1% variance on both. Decoding goes from 62x to 152x realtime — the CPU
half of #28, where the reporter's profile spent ~72% of process CPU inside the
MP3 decoder.

Output is unchanged in quality. The sha256 of the decoded samples does differ,
because the new DCT/IMDCT reorder floating-point operations, so I checked the
metric that matters — compliance against mpg123, upstream's
`TestComplianceDetailedAnalysis`:

| | exact samples | within 1 LSB |
|---|---|---|
| v1.3.0 | 44.75% | 55.25% |
| v1.4.0 | 44.76% | 55.24% |

`default.nix` vendorHash updated by the pre-commit hook.