### PR TITLE
fix(playback): decide the next track from what the player plays, not its state

### DIFF
--- a/internal/playback/service_impl.go
+++ b/internal/playback/service_impl.go
@@ -351,9 +351,12 @@ func (s *serviceImpl) handleTrackFinished() {
 
 	s.emitTrackChange(prevTrack, prevIndex)
 
-	// If player is still playing, this was a gapless transition.
-	// The player already started the next track, don't call Play() again.
-	if s.player.State() == player.Playing {
+	// The player performs gapless transitions itself, so it may already be on
+	// the track the queue just moved to. Ask what it is playing rather than
+	// inferring it from the state: a player left Playing on the *previous* track
+	// (a seek racing the transition) used to be read as a gapless switch, so
+	// nothing was started and playback sat dead on a stale track.
+	if info := s.player.TrackInfo(); info != nil && info.Path == nextTrack.Path {
 		return
 	}
 

--- a/internal/playback/service_impl_test.go
+++ b/internal/playback/service_impl_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/llehouerou/waves/internal/player"
 	"github.com/llehouerou/waves/internal/playlist"
+	"github.com/llehouerou/waves/internal/tags"
 )
 
 const (
@@ -1005,7 +1006,9 @@ func TestService_TrackFinished_AdvancesToNext(t *testing.T) {
 		// Drain initial StateChanged event
 		<-sub.StateChanged
 
-		// Simulate track finishing
+		// Simulate a real gapless transition: the player switched to track 2 by
+		// itself, then reported the previous track finished.
+		p.SetTrackInfo(&tags.FileInfo{Tag: tags.Tag{Path: testSvcPathTrack2}})
 		p.SimulateFinished()
 
 		// Expect TrackChanged event with Index=1 and Current.Path=testSvcPathTrack2
@@ -1020,9 +1023,8 @@ func TestService_TrackFinished_AdvancesToNext(t *testing.T) {
 			t.Errorf("event.Previous.Path = %v, want %s", e.Previous, testSvcPathTrack1)
 		}
 
-		// With gapless playback, when player is still Playing during transition,
-		// Play() is NOT called again - the next track is already playing via gapless streamer.
-		// Only the initial Play() call should have been made.
+		// The player is already on the next track, so Play() must not be called
+		// again. What matters is the track it plays, not its state.
 		calls := p.PlayCalls()
 		if len(calls) != 1 || calls[0] != testSvcPathTrack1 {
 			t.Errorf("PlayCalls() = %v, want [%s] (gapless transition)", calls, testSvcPathTrack1)
@@ -1052,8 +1054,8 @@ func TestService_TrackFinished_NonGapless_AdvancesToNext(t *testing.T) {
 		// Drain initial StateChanged event
 		<-sub.StateChanged
 
-		// Simulate non-gapless transition: player stopped before track finished
-		// (e.g., gapless preload failed, or Stop() was called)
+		// Non-gapless: the player never switched, it is still on (or stopped at)
+		// track 1, so the service must start track 2 itself.
 		p.SetState(player.Stopped)
 		p.SimulateFinished()
 
@@ -1277,4 +1279,32 @@ func drainQueueChanges(sub *Subscription) {
 			return
 		}
 	}
+}
+
+// handleTrackFinished must decide what to start by comparing what the player is
+// actually playing to what the queue moved to, not by reading the player state.
+// A player left Playing on the *old* track — a seek past the end racing the
+// transition — used to be read as "gapless already happened", so nothing was
+// started: the new track's notification showed while playback sat dead.
+func TestService_TrackFinished_StartsNextWhenPlayerStillOnOldTrack(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathB})
+		q.JumpTo(0)
+
+		svc := New(p, q)
+		defer svc.Close()
+
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+		p.SimulateFinished()
+		synctest.Wait()
+
+		calls := p.PlayCalls()
+		if len(calls) != 2 || calls[1] != testSvcPathB {
+			t.Fatalf("play calls = %v, want the next track to be started", calls)
+		}
+	})
 }

--- a/internal/player/mock.go
+++ b/internal/player/mock.go
@@ -42,6 +42,8 @@ func (m *Mock) Play(path string) error {
 		return m.playErr
 	}
 	m.state = Playing
+	// Like the real player: the track being played is now this one.
+	m.trackInfo = &tags.FileInfo{Tag: tags.Tag{Path: path}}
 	return nil
 }
 


### PR DESCRIPTION
## The bug

Holding the seek key across a track boundary left playback dead: the new track's
notification showed, nothing played, play/pause changed the displayed state
without restarting anything, and only "next track" recovered.

## The cause

`handleTrackFinished` inferred a gapless transition from the player state:

```go
// If player is still playing, this was a gapless transition.
// The player already started the next track, don't call Play() again.
if s.player.State() == player.Playing {
    return
}
```

The inference breaks whenever the player is still `Playing` **the previous
track**. A seek landing at the end of a track stops it and signals finished; if
another seek is still in flight the player can be back in `Playing` on the old
track by the time the service looks. The service then concludes the switch
already happened, starts nothing, and playback sits dead on a stale track.

It is the same faulty inference #38 came from — that one was patched by making
the player's state truthful in one path. This removes the inference instead.

## The fix

Compare what the player reports playing to what the queue moved to:

```go
if info := s.player.TrackInfo(); info != nil && info.Path == nextTrack.Path {
    return
}
```

A fact rather than a guess, and self-healing: whatever race occurs, if the player
is not on the expected track the service starts it.

## Test debt this uncovered

- `TestService_TrackFinished_AdvancesToNext` **encoded the bug**: a player left
  `Playing` on track 1 was described as a gapless transition and asserted to need
  no `Play()`. That test is what kept the faulty inference alive. It now
  simulates a real switch, with the player on track 2.
- `Mock.Play` did not record the track it plays, so a test could claim a
  transition the player never made. It now behaves like the real player.

New: `TestService_TrackFinished_StartsNextWhenPlayerStillOnOldTrack`, which fails
on `main`.

## Note

Verified by hand: holding seek across a transition now advances correctly. The
seek work in #43 made this race near-systematic by reaching the end of a track in
under a second, but did not create it — the bug reproduces on `main`.