### PR TITLE
fix(playback): tell a self-started track from a repeat by counting starts

### DIFF
--- a/internal/playback/service_impl.go
+++ b/internal/playback/service_impl.go
@@ -33,6 +33,10 @@ type serviceImpl struct {
 	// lastPlayedPath tracks the path of the last played track.
 	// Used alongside lastPlayedIndex to detect actual track changes.
 	lastPlayedPath string
+	// startsAtPlay is the player's start count when this service last started a
+	// track. If it has moved by the time a track finishes, the player started
+	// something itself (a gapless transition) and there is nothing to launch.
+	startsAtPlay uint64
 
 	subs   []*Subscription
 	subsMu sync.RWMutex
@@ -329,6 +333,14 @@ func (s *serviceImpl) watchTrackFinished() {
 	}
 }
 
+// startPlayback plays a path and records the player's start count, so a later
+// finish can tell whether the player started something on its own.
+func (s *serviceImpl) startPlayback(path string) error {
+	err := s.player.Play(path)
+	s.startsAtPlay = s.player.TrackStarts()
+	return err
+}
+
 // handleTrackFinished advances to the next track when the current track ends.
 func (s *serviceImpl) handleTrackFinished() {
 	s.mu.Lock()
@@ -351,16 +363,17 @@ func (s *serviceImpl) handleTrackFinished() {
 
 	s.emitTrackChange(prevTrack, prevIndex)
 
-	// The player performs gapless transitions itself, so it may already be on
-	// the track the queue just moved to. Ask what it is playing rather than
-	// inferring it from the state: a player left Playing on the *previous* track
-	// (a seek racing the transition) used to be read as a gapless switch, so
-	// nothing was started and playback sat dead on a stale track.
-	if info := s.player.TrackInfo(); info != nil && info.Path == nextTrack.Path {
+	// The player performs gapless transitions itself, so it may already have
+	// started the track the queue just moved to. Neither the state nor the track
+	// path can tell: it is Playing in both cases, and repeat-one or a duplicated
+	// queue entry start the same path again. The start counter can — it only
+	// moves when the player begins a track.
+	if s.player.TrackStarts() != s.startsAtPlay {
+		s.startsAtPlay = s.player.TrackStarts()
 		return
 	}
 
-	if err := s.player.Play(nextTrack.Path); err != nil {
+	if err := s.startPlayback(nextTrack.Path); err != nil {
 		s.player.Stop()
 		s.emitStateChange(StatePlaying, StateStopped)
 		s.emitError("play_next", nextTrack.Path, err)
@@ -504,7 +517,7 @@ func (s *serviceImpl) Play() error {
 	}
 
 	prevState := s.playerStateToState(s.player.State())
-	if err := s.player.Play(track.Path); err != nil {
+	if err := s.startPlayback(track.Path); err != nil {
 		return err
 	}
 
@@ -530,7 +543,7 @@ func (s *serviceImpl) PlayPath(path string) error {
 	defer s.mu.Unlock()
 
 	prevState := s.playerStateToState(s.player.State())
-	if err := s.player.Play(path); err != nil {
+	if err := s.startPlayback(path); err != nil {
 		return err
 	}
 	currState := s.playerStateToState(s.player.State())
@@ -591,7 +604,7 @@ func (s *serviceImpl) Toggle() error {
 		if track == nil {
 			return ErrNoCurrentTrack
 		}
-		if err := s.player.Play(track.Path); err != nil {
+		if err := s.startPlayback(track.Path); err != nil {
 			return err
 		}
 	}
@@ -632,7 +645,7 @@ func (s *serviceImpl) Next() error {
 	s.emitTrackChange(prevTrack, prevIndex)
 
 	if wasActive {
-		if err := s.player.Play(nextTrack.Path); err != nil {
+		if err := s.startPlayback(nextTrack.Path); err != nil {
 			return err
 		}
 	}
@@ -666,7 +679,7 @@ func (s *serviceImpl) Previous() error {
 	s.emitTrackChange(prevTrack, prevIndex)
 
 	if wasActive && newTrack != nil {
-		if err := s.player.Play(newTrack.Path); err != nil {
+		if err := s.startPlayback(newTrack.Path); err != nil {
 			return err
 		}
 	}
@@ -721,7 +734,7 @@ func (s *serviceImpl) JumpTo(index int) error {
 	s.emitTrackChange(prevTrack, prevIndex)
 
 	if wasActive && newTrack != nil {
-		if err := s.player.Play(newTrack.Path); err != nil {
+		if err := s.startPlayback(newTrack.Path); err != nil {
 			return err
 		}
 	}

--- a/internal/playback/service_impl_test.go
+++ b/internal/playback/service_impl_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/llehouerou/waves/internal/player"
 	"github.com/llehouerou/waves/internal/playlist"
-	"github.com/llehouerou/waves/internal/tags"
 )
 
 const (
@@ -1008,8 +1007,7 @@ func TestService_TrackFinished_AdvancesToNext(t *testing.T) {
 
 		// Simulate a real gapless transition: the player switched to track 2 by
 		// itself, then reported the previous track finished.
-		p.SetTrackInfo(&tags.FileInfo{Tag: tags.Tag{Path: testSvcPathTrack2}})
-		p.SimulateFinished()
+		p.SimulateGaplessSwitch(testSvcPathTrack2)
 
 		// Expect TrackChanged event with Index=1 and Current.Path=testSvcPathTrack2
 		e := <-sub.TrackChanged

--- a/internal/playback/transitions_test.go
+++ b/internal/playback/transitions_test.go
@@ -1,0 +1,107 @@
+package playback
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/llehouerou/waves/internal/player"
+	"github.com/llehouerou/waves/internal/playlist"
+)
+
+// Repeat-one: the queue "advances" to the same track, which must be replayed.
+func TestEdge_RepeatOne_ReplaysTrack(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathB})
+		q.JumpTo(0)
+		q.SetRepeatMode(playlist.RepeatOne)
+
+		svc := New(p, q)
+		defer svc.Close()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+
+		p.SimulateFinished()
+		synctest.Wait()
+
+		calls := p.PlayCalls()
+		if len(calls) != 2 || calls[1] != testSvcPathA {
+			t.Errorf("PlayCalls() = %v, want the track replayed", calls)
+		}
+	})
+}
+
+// The same track twice in a row in the queue: the second must be played.
+func TestEdge_DuplicateConsecutiveTrack(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathA})
+		q.JumpTo(0)
+
+		svc := New(p, q)
+		defer svc.Close()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+
+		p.SimulateFinished()
+		synctest.Wait()
+
+		calls := p.PlayCalls()
+		if len(calls) != 2 {
+			t.Errorf("PlayCalls() = %v, want the duplicate played again", calls)
+		}
+	})
+}
+
+// Repeat-all with a single track: the queue wraps onto the same track.
+func TestEdge_RepeatAll_SingleTrack_Replays(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA})
+		q.JumpTo(0)
+		q.SetRepeatMode(playlist.RepeatAll)
+
+		svc := New(p, q)
+		defer svc.Close()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+
+		p.SimulateFinished()
+		synctest.Wait()
+
+		if calls := p.PlayCalls(); len(calls) != 2 {
+			t.Errorf("PlayCalls() = %v, want the single track replayed", calls)
+		}
+	})
+}
+
+// A real gapless switch onto the same path (repeat-one with preload) must not be
+// restarted: the player already began it.
+func TestEdge_RepeatOne_GaplessSwitch_NotRestarted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA})
+		q.JumpTo(0)
+		q.SetRepeatMode(playlist.RepeatOne)
+
+		svc := New(p, q)
+		defer svc.Close()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+
+		p.SimulateGaplessSwitch(testSvcPathA)
+		synctest.Wait()
+
+		if calls := p.PlayCalls(); len(calls) != 1 {
+			t.Errorf("PlayCalls() = %v, want no restart after a gapless switch", calls)
+		}
+	})
+}

--- a/internal/player/interface.go
+++ b/internal/player/interface.go
@@ -30,6 +30,10 @@ type Interface interface {
 	FinishedChan() <-chan struct{}
 	Done() <-chan struct{}
 
+	// TrackStarts counts playback starts, so a consumer can tell a transition
+	// the player made itself from one it must perform.
+	TrackStarts() uint64
+
 	// Gapless playback
 	SetPreloadFunc(fn func() string)
 	SetPreloadDuration(d time.Duration)

--- a/internal/player/mock.go
+++ b/internal/player/mock.go
@@ -22,6 +22,7 @@ type Mock struct {
 	done        chan struct{}
 	volumeLevel float64
 	muted       bool
+	starts      uint64
 }
 
 // NewMock creates a new mock player for testing.
@@ -44,6 +45,7 @@ func (m *Mock) Play(path string) error {
 	m.state = Playing
 	// Like the real player: the track being played is now this one.
 	m.trackInfo = &tags.FileInfo{Tag: tags.Tag{Path: path}}
+	m.starts++
 	return nil
 }
 
@@ -204,6 +206,24 @@ func (m *Mock) SetPosition(d time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.position = d
+}
+
+// TrackStarts counts playback starts, like the real player.
+func (m *Mock) TrackStarts() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.starts
+}
+
+// SimulateGaplessSwitch simulates the player moving to the next track by
+// itself, as gapless playback does.
+func (m *Mock) SimulateGaplessSwitch(path string) {
+	m.mu.Lock()
+	m.trackInfo = &tags.FileInfo{Tag: tags.Tag{Path: path}}
+	m.state = Playing
+	m.starts++
+	m.mu.Unlock()
+	m.SimulateFinished()
 }
 
 // SimulateFinished simulates a track finishing.

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -2,6 +2,7 @@ package player
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gopxl/beep/v2"
@@ -63,6 +64,10 @@ type Player struct {
 	next    *trackState
 	gapless *gaplessStreamer
 
+	// starts counts playback starts, so a consumer can tell whether the player
+	// began a track on its own.
+	starts atomic.Uint64
+
 	// Channels
 	done       chan struct{}
 	finishedCh chan struct{}
@@ -106,6 +111,13 @@ func (p *Player) Done() <-chan struct{} {
 
 // State returns the current playback state.
 func (p *Player) State() State { return p.state }
+
+// TrackStarts counts how many times playback of a track has begun, whether
+// from Play or from a gapless transition the player made itself. A consumer
+// that remembers the count can tell whether the player started something on
+// its own, which the state and the track path cannot distinguish: repeat-one
+// and a duplicated queue entry play the same path again.
+func (p *Player) TrackStarts() uint64 { return p.starts.Load() }
 
 // TrackInfo returns metadata about the currently playing track.
 func (p *Player) TrackInfo() *tags.FileInfo {

--- a/internal/player/stream.go
+++ b/internal/player/stream.go
@@ -149,6 +149,7 @@ func (p *Player) Play(path string) error {
 	}
 
 	p.state = Playing
+	p.starts.Add(1)
 	p.done = make(chan struct{})
 
 	if p.monitorDone != nil {
@@ -229,6 +230,7 @@ func (p *Player) handleGaplessTransition() {
 
 	p.current = p.next
 	p.next = nil
+	p.starts.Add(1) // the player started this track by itself
 
 	select {
 	case p.finishedCh <- struct{}{}:


### PR DESCRIPTION
Fixes a regression I introduced in #44 (already on `main`).

## The bug

#44 replaced a state inference with a path comparison:

```go
if info := s.player.TrackInfo(); info != nil && info.Path == nextTrack.Path {
    return // the player already switched
}
```

That confuses two different situations. Whenever the next track is the *same
file*, the comparison is true even though the player never switched, so nothing
gets started and playback stops:

- repeat-one
- repeat-all on a single-track queue
- the same track twice in a row in the queue

## The fix

Neither the state nor the path answers the actual question — did the player begin
a track on its own? So the player says it: `Player.TrackStarts()` counts playback
starts, incremented in `Play` and in `handleGaplessTransition`, the only two places
a track begins. The service records the count when it starts a track and compares
when one finishes.

All service-initiated playback goes through `startPlayback` so the recorded count
cannot drift from the player's.

## Tests

`internal/playback/transitions_test.go`:

- repeat-one replays the track
- repeat-all on one track replays it
- a duplicated consecutive queue entry is played again
- a genuine gapless switch onto the same path is *not* restarted

The first three fail on `main`.

`Mock.SimulateGaplessSwitch` was added so a test has to model a real switch —
setting the path alone no longer lets a test claim a transition the player never
made.

## Verified by hand

repeat-one, repeat-all, duplicate entry and radio mode all behave correctly.