### PR TITLE
fix(importer): run one attempt at a time instead of abandoning it

### DIFF
--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -338,6 +338,14 @@ func moveFile(src, dst string) error {
 
 // retryWithBackoff executes an operation with exponential backoff retry.
 // Returns the last error if all retries fail.
+//
+// The operation runs to completion before the next attempt starts. It used to
+// run in a goroutine abandoned on a per-attempt deadline, which did not stop it:
+// the retry then wrote the same file alongside it, and the abandoned attempt
+// could finish last and undo the retry (issue #48). Since none of the wrapped
+// operations — write tags, mkdir, copy, move — can be interrupted, a deadline
+// buys nothing and costs correctness. ctx is honoured between attempts, where it
+// can actually take effect.
 func retryWithBackoff(ctx context.Context, operation string, fn func() error) error {
 	var lastErr error
 	backoff := initialBackoff
@@ -354,28 +362,18 @@ func retryWithBackoff(ctx context.Context, operation string, fn func() error) er
 			backoff = min(backoff*2, maxBackoff)
 		}
 
-		// Execute with timeout
-		done := make(chan error, 1)
-		go func() {
-			done <- fn()
-		}()
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
 
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("%s: cancelled: %w", operation, ctx.Err())
-		case err := <-done:
-			if err == nil {
-				return nil
-			}
-			lastErr = err
-			// Check if error is retryable (file locks, temporary network issues)
-			if !isRetryableError(err) {
-				return fmt.Errorf("%s: %w", operation, err)
-			}
-			// Continue to retry
-		case <-time.After(operationTimeout):
-			lastErr = fmt.Errorf("timeout after %v", operationTimeout)
-			// Continue to retry on timeout
+		// Check if error is retryable (file locks, temporary network issues)
+		if !isRetryableError(err) {
+			return fmt.Errorf("%s: %w", operation, err)
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("%s: cancelled: %w", operation, ctxErr)
 		}
 	}
 

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -271,53 +272,24 @@ func TestIsRetryableError_Categories(t *testing.T) {
 	}
 }
 
-func TestRetryWithBackoff_OperationTimeout(t *testing.T) {
+// A slow operation is retried after it returns, not on top of itself: each
+// attempt runs to completion first. The per-attempt deadline that used to
+// abandon it is gone (issue #48).
+func TestRetryWithBackoff_SlowOperationIsRetriedAfterItReturns(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		ctx := context.Background()
 		callCount := 0
 
-		// Each operation blocks until the timeout channel is ready
-		// Then it receives and continues (simulating slow operation that finishes just after timeout)
-		blockChan := make(chan struct{})
+		err := RetryWithBackoff(context.Background(), "slow op", func() error {
+			callCount++
+			time.Sleep(TestOperationTimeout + time.Second) // slower than the old deadline
+			return errors.New("temporary failure")         // retryable
+		})
 
-		done := make(chan error, 1)
-		go func() {
-			done <- RetryWithBackoff(ctx, "slow op", func() error {
-				callCount++
-				// Wait on a channel that will be unblocked after timeout fires
-				<-blockChan
-				return errors.New("temporary failure")
-			})
-		}()
-
-		// For each attempt, wait for operation timeout + a bit, then unblock
-		for range 1 + TestMaxRetries {
-			// Wait for operation timeout
-			time.Sleep(TestOperationTimeout + 100*time.Millisecond)
-			synctest.Wait()
-			// Unblock the goroutine so it can exit cleanly
-			select {
-			case blockChan <- struct{}{}:
-			default:
-			}
+		if err == nil {
+			t.Fatal("expected an error after the retries are exhausted")
 		}
-
-		// Wait for backoff delays and completion
-		time.Sleep(4 * time.Second)
-		synctest.Wait()
-
-		select {
-		case err := <-done:
-			if err == nil {
-				t.Fatal("expected error after operation timeouts")
-			}
-		default:
-			t.Fatal("RetryWithBackoff did not complete")
-		}
-
-		expectedCalls := 1 + TestMaxRetries
-		if callCount != expectedCalls {
-			t.Errorf("callCount = %d, want %d", callCount, expectedCalls)
+		if expected := 1 + TestMaxRetries; callCount != expected {
+			t.Errorf("callCount = %d, want %d", callCount, expected)
 		}
 	})
 }
@@ -336,4 +308,36 @@ func TestConstants(t *testing.T) {
 	if TestOperationTimeout != 30*time.Second {
 		t.Errorf("operationTimeout = %v, want 30s", TestOperationTimeout)
 	}
+}
+
+// Two attempts must never run at the same time. The operations wrapped by
+// retryWithBackoff are file mutations — write tags, copy, move — so overlapping
+// attempts write the same destination concurrently, and the abandoned one can
+// finish after the retry, undoing it (issue #48).
+func TestRetryWithBackoff_AttemptsNeverOverlap(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var running, maxSeen atomic.Int32
+
+		err := RetryWithBackoff(context.Background(), "slow op", func() error {
+			n := running.Add(1)
+			defer running.Add(-1)
+			for {
+				seen := maxSeen.Load()
+				if n <= seen || maxSeen.CompareAndSwap(seen, n) {
+					break
+				}
+			}
+			// Outlasts any per-attempt deadline, so an implementation that
+			// abandons the attempt starts the next one on top of this one.
+			time.Sleep(TestOperationTimeout + time.Second)
+			return errors.New("file is locked") // retryable, so it tries again
+		})
+
+		if err == nil {
+			t.Fatal("expected the operation to fail after its retries")
+		}
+		if got := maxSeen.Load(); got > 1 {
+			t.Errorf("%d attempts ran concurrently, want at most 1", got)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #48.

## The bug

`retryWithBackoff` ran the operation in a goroutine and abandoned it on a
per-attempt deadline:

```go
done := make(chan error, 1)
go func() { done <- fn() }()

select {
case err := <-done:
    ...
case <-time.After(operationTimeout):
    lastErr = fmt.Errorf("timeout after %v", operationTimeout)
    // Continue to retry on timeout
}
```

The goroutine kept running, so after one timeout **two invocations ran
concurrently**. What is wrapped are file mutations:

| | |
|---|---|
| `write tags` | `importer.go:114`, `:245` |
| `create directory` | `:123` |
| `copy file` | `:132` |
| `move file` | `:139` |

So the retry wrote the same destination while the previous attempt was still
writing it, and the abandoned attempt could finish *after* the retry and undo it.
`moveFile` ends in `os.Remove(src)`, which could also delete the source while the
other copy was reading it.

A timeout fires precisely when the disk or mount is slow rather than dead — the
case where the first attempt is still very much alive.

## The fix

None of those operations can be interrupted, so the deadline never stopped any
work: it only duplicated it, while reporting failure to the caller. Each attempt
now runs to completion before the next begins, and `ctx` is checked between
attempts, where it can actually take effect.

The goroutine and the `select` go away, so the function is shorter than it was.
`RetagFile` keeps its overall context timeout, which now bounds the retries
rather than pretending to bound the work.

**Trade-off, stated plainly**: a genuinely stuck operation now blocks its import
job instead of returning early. It always blocked — the goroutine stayed stuck
either way — but the caller used to be told it had finished. Blocking honestly
beats continuing on a half-written file.

## Tests

- `TestRetryWithBackoff_AttemptsNeverOverlap` states the invariant and fails on
  `main` with "2 attempts ran concurrently".
- The old `TestRetryWithBackoff_OperationTimeout` described the abandoned-goroutine
  behaviour it was meant to catch, so it becomes
  `TestRetryWithBackoff_SlowOperationIsRetriedAfterItReturns`: same scenario,
  honest expectation.

`go test ./internal/importer -race` is now clean; this was the race left over
from the sweep in #47.