### PR TITLE
chore(release): use Claude Sonnet 5 for release notes, and stop publishing "null"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           - Be factual, don't invent features"
 
           PAYLOAD=$(jq -n \
-            --arg model "claude-sonnet-4-5" \
+            --arg model "claude-sonnet-5" \
             --arg system "$SYSTEM_PROMPT" \
             --arg commits "$COMMITS" \
             '{
@@ -76,8 +76,16 @@ jobs:
             -H "content-type: application/json" \
             -d "$PAYLOAD")
 
-          # Extract and write release notes
-          echo "$RESPONSE" | jq -r '.content[0].text' > release-notes.md
+          # Extract release notes, falling back to the commit list. Without this,
+          # an API error writes "null" into the published release notes.
+          NOTES=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
+          if [ -z "$NOTES" ]; then
+            echo "::warning::Release notes generation failed, using the commit list"
+            echo "$RESPONSE" | head -c 500
+            printf '%s\n' "$COMMITS" > release-notes.md
+          else
+            printf '%s\n' "$NOTES" > release-notes.md
+          fi
 
           echo "Generated release notes:"
           cat release-notes.md


### PR DESCRIPTION
## Model

`claude-sonnet-4-5` is two generations behind. Per Anthropic's current model
list, Sonnet 5's API id is `claude-sonnet-5` — the 4.6+ generation uses the
dateless format, and unlike the pre-4.6 aliases it is a **fixed snapshot**, not
a pointer that moves under us. So this stays reproducible without pinning a date.

## The "null" release notes

The extraction was:

```sh
echo "$RESPONSE" | jq -r '.content[0].text' > release-notes.md
```

`jq -r` prints the literal string `null` when the field is absent — an API error,
a rate limit, an empty body. That string went straight into the published GitHub
release, with nothing between it and users. Nothing in the workflow checked.

It now falls back to the commit list and logs a warning, so a bad API call costs
us plain notes instead of a release that reads `null`.

Verified the four response shapes against the extraction snippet: normal
response, API error object, empty body, empty `content` array.