### PR TITLE
refactor(playback): collapse the four queue transitions into one

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# CONTEXT
+
+Domain vocabulary for waves. Use these words in code, comments, commits and
+issues; reach for one of them before inventing a new one.
+
+## Playback
+
+**Transition** — one move of the queue position and everything that must follow
+it: the track being left is captured, the queue moves, what was played is
+recorded, `TrackChange` is emitted, and the new track is started when the
+transition asks for it. Four things start one: a track finishing, `Next`,
+`Previous`, `JumpTo`. They differ only in their precondition, their queue move,
+their start rule and what they do when the queue is exhausted; the rest lives
+once in `serviceImpl.applyTransition`.
+
+**Last-played** — the queue index and track path the playback service last
+started. Not the same as the queue's current position: the queue can be moved
+without playing (`QueueAdvance`, `QueueMoveTo`), and `Play` uses the difference
+between the two to decide whether a track really changed.
+
+**Gapless self-start** — the player moving to the next track by itself, without
+being told. It makes a finished track ambiguous: the player is Playing either
+way, and repeat-one or a duplicated queue entry start the same path again.
+`player.TrackStarts()` is the only thing that can tell them apart, because it
+only moves when the player begins a track.
+
+**Exhausted** — a queue move that has nowhere to go: `Next` at the end with
+repeat off. Distinct from a *precondition* failure, which is checked before the
+move happens (`Previous` at index 0, `JumpTo` out of bounds).

--- a/internal/playback/service_impl.go
+++ b/internal/playback/service_impl.go
@@ -375,8 +375,8 @@ type transition struct {
 
 // applyTransition performs one queue transition: it captures the track being
 // left, moves the queue, records what was played, starts the new track when the
-// transition asks for it, and reports the change. It returns any error from
-// starting playback; the path that failed is s.lastPlayedPath.
+// transition asks for it, and reports the change. A failed start stops the
+// player and emits StateChange and ErrorEvent before the error is returned.
 //
 // Must be called with s.mu held. The start step releases and reacquires s.mu
 // while the player opens the file (issue #45), so state captured before a
@@ -397,7 +397,12 @@ func (s *serviceImpl) applyTransition(t transition) error {
 	s.lastPlayedPath = next.Path
 
 	if t.shouldStart() {
+		// A track that will not open leaves the queue already moved, so the
+		// player must not be left running on a track nobody is on. Stop it and
+		// report, whoever asked for the transition.
 		if err := s.startPlayback(next.Path); err != nil {
+			s.stopAndEmitLocked()
+			s.emitError("play_next", next.Path, err)
 			return err
 		}
 	}
@@ -439,7 +444,7 @@ func (s *serviceImpl) handleTrackFinished() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	err := s.applyTransition(transition{
+	_ = s.applyTransition(transition{
 		move: s.queue.Next,
 		// The player performs gapless transitions itself, so it may already
 		// have started the track the queue just moved to. Neither the state nor
@@ -454,11 +459,7 @@ func (s *serviceImpl) handleTrackFinished() {
 			return true
 		},
 		onExhausted: s.stopFromPlayingLocked,
-	})
-	if err != nil {
-		s.stopFromPlayingLocked()
-		s.emitError("play_next", s.lastPlayedPath, err)
-	}
+	}) //nolint:errcheck // nothing to return it to: this runs on the watcher goroutine, and applyTransition already reported it
 }
 
 // emitStateChange notifies all subscribers of a state change.

--- a/internal/playback/service_impl.go
+++ b/internal/playback/service_impl.go
@@ -361,49 +361,104 @@ func (s *serviceImpl) startPlayback(path string) error {
 	return err
 }
 
+// transition describes one queue move and everything that must follow it.
+type transition struct {
+	// move advances the queue position and returns the track now current, or
+	// nil when the queue is exhausted.
+	move func() *playlist.Track
+	// shouldStart reports whether the player must be told to play the track
+	// moved to. It runs after the move, before TrackChange is emitted.
+	shouldStart func() bool
+	// onExhausted runs when move returns nil. Optional.
+	onExhausted func()
+}
+
+// applyTransition performs one queue transition: it captures the track being
+// left, moves the queue, records what was played, starts the new track when the
+// transition asks for it, and reports the change. It returns any error from
+// starting playback; the path that failed is s.lastPlayedPath.
+//
+// Must be called with s.mu held. The start step releases and reacquires s.mu
+// while the player opens the file (issue #45), so state captured before a
+// transition can be stale after it.
+func (s *serviceImpl) applyTransition(t transition) error {
+	prevTrack := s.currentTrackLocked()
+	prevIndex := s.queue.CurrentIndex()
+
+	next := t.move()
+	if next == nil {
+		if t.onExhausted != nil {
+			t.onExhausted()
+		}
+		return nil
+	}
+
+	s.lastPlayedIndex = s.queue.CurrentIndex()
+	s.lastPlayedPath = next.Path
+
+	if t.shouldStart() {
+		if err := s.startPlayback(next.Path); err != nil {
+			return err
+		}
+	}
+
+	// Only now, with the track it moved to playing: seeking past the end stops
+	// the player before signalling finished (issue #38), and a subscriber that
+	// reads the live state on TrackChange would otherwise see Stopped and keep
+	// that stale view until the next state change.
+	s.emitTrackChange(prevTrack, prevIndex)
+	return nil
+}
+
+// isActiveLocked reports whether the player is playing or paused, which is what
+// makes a user-initiated transition start the track it moves to.
+// Must be called while holding mu.
+func (s *serviceImpl) isActiveLocked() bool {
+	state := s.player.State()
+	return state == player.Playing || state == player.Paused
+}
+
+// stopAndEmitLocked stops the player and reports the state it left.
+// Must be called while holding mu.
+func (s *serviceImpl) stopAndEmitLocked() {
+	prevState := s.playerStateToState(s.player.State())
+	s.player.Stop()
+	s.emitStateChange(prevState, s.playerStateToState(s.player.State()))
+}
+
+// stopFromPlayingLocked stops the player and reports the stop as coming from
+// Playing, which is what a track finishing always is.
+// Must be called while holding mu.
+func (s *serviceImpl) stopFromPlayingLocked() {
+	s.player.Stop()
+	s.emitStateChange(StatePlaying, StateStopped)
+}
+
 // handleTrackFinished advances to the next track when the current track ends.
 func (s *serviceImpl) handleTrackFinished() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	prevTrack := s.currentTrackLocked()
-	prevIndex := s.queue.CurrentIndex()
-
-	nextTrack := s.queue.Next()
-	if nextTrack == nil {
-		// End of queue
-		s.player.Stop()
-		s.emitStateChange(StatePlaying, StateStopped)
-		return
+	err := s.applyTransition(transition{
+		move: s.queue.Next,
+		// The player performs gapless transitions itself, so it may already
+		// have started the track the queue just moved to. Neither the state nor
+		// the track path can tell: it is Playing in both cases, and repeat-one
+		// or a duplicated queue entry start the same path again. The start
+		// counter can — it only moves when the player begins a track.
+		shouldStart: func() bool {
+			if s.player.TrackStarts() != s.startsAtPlay {
+				s.startsAtPlay = s.player.TrackStarts()
+				return false
+			}
+			return true
+		},
+		onExhausted: s.stopFromPlayingLocked,
+	})
+	if err != nil {
+		s.stopFromPlayingLocked()
+		s.emitError("play_next", s.lastPlayedPath, err)
 	}
-
-	// Update last played tracking
-	s.lastPlayedIndex = s.queue.CurrentIndex()
-	s.lastPlayedPath = nextTrack.Path
-
-	// The player performs gapless transitions itself, so it may already have
-	// started the track the queue just moved to. Neither the state nor the track
-	// path can tell: it is Playing in both cases, and repeat-one or a duplicated
-	// queue entry start the same path again. The start counter can — it only
-	// moves when the player begins a track.
-	if s.player.TrackStarts() != s.startsAtPlay {
-		s.startsAtPlay = s.player.TrackStarts()
-		s.emitTrackChange(prevTrack, prevIndex)
-		return
-	}
-
-	if err := s.startPlayback(nextTrack.Path); err != nil {
-		s.player.Stop()
-		s.emitStateChange(StatePlaying, StateStopped)
-		s.emitError("play_next", nextTrack.Path, err)
-		return
-	}
-
-	// Only now, with the next track playing: seeking past the end stops the
-	// player before signalling finished (issue #38), and a subscriber that reads
-	// the live state on TrackChange would otherwise see Stopped and keep that
-	// stale view until the next state change.
-	s.emitTrackChange(prevTrack, prevIndex)
 }
 
 // emitStateChange notifies all subscribers of a state change.
@@ -647,35 +702,17 @@ func (s *serviceImpl) Next() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	prevTrack := s.currentTrackLocked()
-	prevIndex := s.queue.CurrentIndex()
-	wasActive := s.player.State() == player.Playing || s.player.State() == player.Paused
-
-	nextTrack := s.queue.Next()
-
-	if nextTrack == nil {
-		// At end of queue
-		if wasActive {
-			prevState := s.playerStateToState(s.player.State())
-			s.player.Stop()
-			currState := s.playerStateToState(s.player.State())
-			s.emitStateChange(prevState, currState)
-		}
-		return nil
-	}
-
-	// Update last played tracking
-	s.lastPlayedIndex = s.queue.CurrentIndex()
-	s.lastPlayedPath = nextTrack.Path
-
-	s.emitTrackChange(prevTrack, prevIndex)
-
-	if wasActive {
-		if err := s.startPlayback(nextTrack.Path); err != nil {
-			return err
-		}
-	}
-	return nil
+	wasActive := s.isActiveLocked()
+	err := s.applyTransition(transition{
+		move:        s.queue.Next,
+		shouldStart: func() bool { return wasActive },
+		onExhausted: func() {
+			if wasActive {
+				s.stopAndEmitLocked()
+			}
+		},
+	})
+	return err
 }
 
 // Previous goes back to the previous track in the queue.
@@ -690,26 +727,12 @@ func (s *serviceImpl) Previous() error {
 		return nil // At start, no-op
 	}
 
-	prevTrack := s.currentTrackLocked()
-	prevIndex := currentIndex
-	wasActive := s.player.State() == player.Playing || s.player.State() == player.Paused
-
-	newTrack := s.queue.JumpTo(currentIndex - 1)
-
-	// Update last played tracking
-	s.lastPlayedIndex = s.queue.CurrentIndex()
-	if newTrack != nil {
-		s.lastPlayedPath = newTrack.Path
-	}
-
-	s.emitTrackChange(prevTrack, prevIndex)
-
-	if wasActive && newTrack != nil {
-		if err := s.startPlayback(newTrack.Path); err != nil {
-			return err
-		}
-	}
-	return nil
+	wasActive := s.isActiveLocked()
+	err := s.applyTransition(transition{
+		move:        func() *playlist.Track { return s.queue.JumpTo(currentIndex - 1) },
+		shouldStart: func() bool { return wasActive },
+	})
+	return err
 }
 
 // Seek adjusts the playback position by the given delta.
@@ -739,32 +762,16 @@ func (s *serviceImpl) JumpTo(index int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Validate bounds
-	tracks := s.queue.Tracks()
-	if index < 0 || index >= len(tracks) {
+	if index < 0 || index >= len(s.queue.Tracks()) {
 		return ErrInvalidIndex
 	}
 
-	prevTrack := s.currentTrackLocked()
-	prevIndex := s.queue.CurrentIndex()
-	wasActive := s.player.State() == player.Playing || s.player.State() == player.Paused
-
-	newTrack := s.queue.JumpTo(index)
-
-	// Update last played tracking
-	s.lastPlayedIndex = s.queue.CurrentIndex()
-	if newTrack != nil {
-		s.lastPlayedPath = newTrack.Path
-	}
-
-	s.emitTrackChange(prevTrack, prevIndex)
-
-	if wasActive && newTrack != nil {
-		if err := s.startPlayback(newTrack.Path); err != nil {
-			return err
-		}
-	}
-	return nil
+	wasActive := s.isActiveLocked()
+	err := s.applyTransition(transition{
+		move:        func() *playlist.Track { return s.queue.JumpTo(index) },
+		shouldStart: func() bool { return wasActive },
+	})
+	return err
 }
 
 // SetRepeatMode sets the repeat mode.

--- a/internal/playback/transitions_test.go
+++ b/internal/playback/transitions_test.go
@@ -347,10 +347,11 @@ func TestTransition_Finished_StartFails_StopsAndReportsError(t *testing.T) {
 	})
 }
 
-// A failed open on Next currently returns the error and nothing else: the queue
-// has moved, the player is untouched, and no event tells anyone. Issue #52
-// changes this; the test pins today's behaviour first.
-func TestTransition_Next_StartFails_ReturnsErrorOnly(t *testing.T) {
+// A failed open on Next stops the player and reports it, the same as a failed
+// open on a track finish. Before issue #52 it returned the error and nothing
+// else, leaving the queue moved onto a track that was not playing while the
+// player kept running on the old one, with no event to tell anyone.
+func TestTransition_Next_StartFails_StopsAndReportsError(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		p := player.NewMock()
 		q := playlist.NewQueue()
@@ -371,16 +372,20 @@ func TestTransition_Next_StartFails_ReturnsErrorOnly(t *testing.T) {
 		if err == nil {
 			t.Fatal("Next() error = nil, want the open failure")
 		}
-		if svc.QueueCurrentIndex() != 1 {
-			t.Errorf("QueueCurrentIndex() = %d, want 1: the queue moved anyway", svc.QueueCurrentIndex())
+		if svc.State() != StateStopped {
+			t.Errorf("State() = %v, want Stopped", svc.State())
 		}
-		if svc.State() != StatePlaying {
-			t.Errorf("State() = %v, want Playing: the player is left as it was", svc.State())
+		e := <-sub.StateChanged
+		if e.Previous != StatePlaying || e.Current != StateStopped {
+			t.Errorf("StateChange = %v -> %v, want Playing -> Stopped", e.Previous, e.Current)
 		}
 		select {
 		case ev := <-sub.Error:
-			t.Errorf("ErrorEvent %v emitted, want none today", ev)
+			if ev.Path != testSvcPathB {
+				t.Errorf("ErrorEvent.Path = %q, want %q", ev.Path, testSvcPathB)
+			}
 		default:
+			t.Error("no ErrorEvent emitted for a failed open on Next")
 		}
 	})
 }

--- a/internal/playback/transitions_test.go
+++ b/internal/playback/transitions_test.go
@@ -1,6 +1,7 @@
 package playback
 
 import (
+	"errors"
 	"testing"
 	"testing/synctest"
 
@@ -146,6 +147,240 @@ func TestEdge_SeekPastEnd_TrackChangeAfterNextStarted(t *testing.T) {
 		}
 		if svc.State() != StatePlaying {
 			t.Errorf("State() = %v at TrackChange, want Playing", svc.State())
+		}
+	})
+}
+
+// The tests below pin the behaviour of the four queue transitions
+// (handleTrackFinished, Next, Previous, JumpTo) at the edges where they
+// currently diverge, so the collapse into one transition can be shown to change
+// nothing. See issue #52.
+
+// A paused player is still active: Next must start the track it moved to.
+func TestTransition_Next_WhilePaused_StartsNextTrack(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathB})
+		q.JumpTo(0)
+
+		svc := New(p, q)
+		defer svc.Close()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+		if err := svc.Pause(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := svc.Next(); err != nil {
+			t.Fatalf("Next() error = %v", err)
+		}
+
+		calls := p.PlayCalls()
+		if len(calls) != 2 || calls[1] != testSvcPathB {
+			t.Errorf("PlayCalls() = %v, want the next track started from paused", calls)
+		}
+	})
+}
+
+// Next at the end of the queue while paused stops, and the StateChange reports
+// Paused as the previous state.
+func TestTransition_Next_AtEndWhilePaused_StopsFromPaused(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA})
+		q.JumpTo(0)
+
+		svc := New(p, q)
+		defer svc.Close()
+		sub := svc.Subscribe()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+		<-sub.StateChanged
+		if err := svc.Pause(); err != nil {
+			t.Fatal(err)
+		}
+		<-sub.StateChanged
+
+		if err := svc.Next(); err != nil {
+			t.Fatalf("Next() error = %v", err)
+		}
+
+		e := <-sub.StateChanged
+		if e.Previous != StatePaused || e.Current != StateStopped {
+			t.Errorf("StateChange = %v -> %v, want Paused -> Stopped", e.Previous, e.Current)
+		}
+		if svc.State() != StateStopped {
+			t.Errorf("State() = %v, want Stopped", svc.State())
+		}
+	})
+}
+
+// Previous from a paused player starts the track it moved to.
+func TestTransition_Previous_WhilePaused_StartsPreviousTrack(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathB})
+		q.JumpTo(1)
+
+		svc := New(p, q)
+		defer svc.Close()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+		if err := svc.Pause(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := svc.Previous(); err != nil {
+			t.Fatalf("Previous() error = %v", err)
+		}
+
+		calls := p.PlayCalls()
+		if len(calls) != 2 || calls[1] != testSvcPathA {
+			t.Errorf("PlayCalls() = %v, want the previous track started from paused", calls)
+		}
+	})
+}
+
+// Previous while stopped moves the queue and reports it, but starts nothing.
+func TestTransition_Previous_WhileStopped_MovesWithoutPlaying(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathB})
+		q.JumpTo(1)
+
+		svc := New(p, q)
+		defer svc.Close()
+		sub := svc.Subscribe()
+
+		if err := svc.Previous(); err != nil {
+			t.Fatalf("Previous() error = %v", err)
+		}
+
+		e := <-sub.TrackChanged
+		if e.Index != 0 {
+			t.Errorf("TrackChange.Index = %d, want 0", e.Index)
+		}
+		if e.Previous == nil || e.Previous.Path != testSvcPathB {
+			t.Errorf("TrackChange.Previous = %v, want %s", e.Previous, testSvcPathB)
+		}
+		if len(p.PlayCalls()) != 0 {
+			t.Errorf("PlayCalls() = %v, want none while stopped", p.PlayCalls())
+		}
+	})
+}
+
+// JumpTo from a paused player starts the track it moved to.
+func TestTransition_JumpTo_WhilePaused_StartsTargetTrack(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(
+			playlist.Track{Path: testSvcPathA},
+			playlist.Track{Path: testSvcPathB},
+			playlist.Track{Path: testSvcPathC},
+		)
+		q.JumpTo(0)
+
+		svc := New(p, q)
+		defer svc.Close()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+		if err := svc.Pause(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := svc.JumpTo(2); err != nil {
+			t.Fatalf("JumpTo() error = %v", err)
+		}
+
+		calls := p.PlayCalls()
+		if len(calls) != 2 || calls[1] != testSvcPathC {
+			t.Errorf("PlayCalls() = %v, want the target track started from paused", calls)
+		}
+	})
+}
+
+// A failed open on a track finish stops the player and reports both the state
+// change and the error.
+func TestTransition_Finished_StartFails_StopsAndReportsError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathB})
+		q.JumpTo(0)
+
+		svc := New(p, q)
+		defer svc.Close()
+		sub := svc.Subscribe()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+		<-sub.StateChanged
+
+		p.SetPlayError(errors.New("open failed"))
+		p.SimulateFinished()
+		synctest.Wait()
+
+		e := <-sub.StateChanged
+		if e.Current != StateStopped {
+			t.Errorf("StateChange.Current = %v, want Stopped", e.Current)
+		}
+		select {
+		case ev := <-sub.Error:
+			if ev.Path != testSvcPathB {
+				t.Errorf("ErrorEvent.Path = %q, want %q", ev.Path, testSvcPathB)
+			}
+		default:
+			t.Error("no ErrorEvent emitted for a failed open on finish")
+		}
+		if svc.State() != StateStopped {
+			t.Errorf("State() = %v, want Stopped", svc.State())
+		}
+	})
+}
+
+// A failed open on Next currently returns the error and nothing else: the queue
+// has moved, the player is untouched, and no event tells anyone. Issue #52
+// changes this; the test pins today's behaviour first.
+func TestTransition_Next_StartFails_ReturnsErrorOnly(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		p := player.NewMock()
+		q := playlist.NewQueue()
+		q.Add(playlist.Track{Path: testSvcPathA}, playlist.Track{Path: testSvcPathB})
+		q.JumpTo(0)
+
+		svc := New(p, q)
+		defer svc.Close()
+		sub := svc.Subscribe()
+		if err := svc.Play(); err != nil {
+			t.Fatal(err)
+		}
+		<-sub.StateChanged
+
+		p.SetPlayError(errors.New("open failed"))
+		err := svc.Next()
+
+		if err == nil {
+			t.Fatal("Next() error = nil, want the open failure")
+		}
+		if svc.QueueCurrentIndex() != 1 {
+			t.Errorf("QueueCurrentIndex() = %d, want 1: the queue moved anyway", svc.QueueCurrentIndex())
+		}
+		if svc.State() != StatePlaying {
+			t.Errorf("State() = %v, want Playing: the player is left as it was", svc.State())
+		}
+		select {
+		case ev := <-sub.Error:
+			t.Errorf("ErrorEvent %v emitted, want none today", ev)
+		default:
 		}
 	})
 }


### PR DESCRIPTION
`handleTrackFinished`, `Next`, `Previous` and `JumpTo` each open-coded the same
queue transition, with different behaviour at the edges. They now go through one
`applyTransition`.

- characterization tests first, pinning the four transitions at their edges
- collapse into `applyTransition`
- a failed open now stops the player and emits StateChange + ErrorEvent for all
  four (it used to be a bare return outside the finish path)
- `CONTEXT.md` seeded with the transition vocabulary

Rebased on main after v0.1.48: `applyTransition` emits `TrackChange` only once the
track it moved to is playing, keeping the fix from 2f3ac2a (seeking past the end
stops the player first, and the UI sizes its layout from the live state).

Closes #52